### PR TITLE
Add CI

### DIFF
--- a/.ci-dockerfiles/ci-base.dockerfile
+++ b/.ci-dockerfiles/ci-base.dockerfile
@@ -1,0 +1,19 @@
+from haskell:8.2
+
+run apt-get update && apt-get install -y \
+  clang lld-4.0 \
+  curl wget \
+  chicken-bin racket \
+  libx11-dev uuid-dev \
+  libncurses5-dev
+
+run wget https://github.com/cisco/ChezScheme/archive/v9.5.2.tar.gz && \
+  tar xvzf v9.5.2.tar.gz && \
+  cd ChezScheme-9.5.2 && \
+  ./configure --threads && \
+  make -j install
+
+run cabal update && cabal install -j --with-ld=ld.lld-4.0 idris-1.3.2
+
+env IDRIS_CC=clang
+cmd idris

--- a/.ci-dockerfiles/ci-run.dockerfile
+++ b/.ci-dockerfiles/ci-run.dockerfile
@@ -1,0 +1,7 @@
+from theodus/idris2-ci-base:latest
+
+copy . /Idris2-dev
+workdir /Idris2-dev
+run make idris2
+run make libs
+run make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: bionic
+
+services: docker
+
+language: minimal
+
+before_install: docker pull theodus/idris2-ci-base:latest
+
+script: docker build . -f .ci-dockerfiles/ci-run.dockerfile


### PR DESCRIPTION
This PR adds a Travis CI configuration. Currently this is using a set of Docker containers on a minimal Travis image to avoid building both Idris and Idris2 during each CI run.