### PR TITLE
fix implicit/brace block ambiguity in records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 *.ibc
+*.ttc
+*.ttm
 
 idris2
 runtests

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1151,13 +1151,16 @@ recordDecl fname indents
          n <- name
          params <- many (ifaceParam fname indents)
          keyword "where"
-         dc <- option Nothing (do exactIdent "constructor"
-                                  n <- name
-                                  pure (Just n))
-         flds <- assert_total (blockAfter col (fieldDecl fname))
+         dcflds <- blockWithOptHeaderAfter col ctor (fieldDecl fname)
          end <- location
          pure (PRecord (MkFC fname start end) 
-                       vis n params dc (concat flds))
+                       vis n params (fst dcflds) (concat (snd dcflds)))
+  where
+  ctor : IndentInfo -> Rule Name
+  ctor idt = do exactIdent "constructor"
+                n <- name
+                atEnd idt
+                pure n
 
 claim : FileName -> IndentInfo -> Rule PDecl
 claim fname indents


### PR DESCRIPTION
Resolves the ambiguity between 
```
record Foo where 
  constructor MkFoo
  <brace block>
```
and
```
record Foo where
  constructor MkFoo
  { field : Ty }
```
by moving constructor parsing into the block. 
Partially resolves #46.