### PR TITLE
Only display IDE port when listening

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -54,7 +54,6 @@ initIDESocketFile p = do
       putStrLn "Failed to open socket"
       exit 1
     Right sock => do
-      putStrLn (show p)
       res <- bind sock (Just (Hostname "localhost")) p
       if res /= 0 
       then 
@@ -65,6 +64,7 @@ initIDESocketFile p = do
         then
           pure (Left ("Failed to listen on socket with error: " ++ show res))
         else do
+          putStrLn (show p)
           res <- accept sock
           case res of 
             Left err => 


### PR DESCRIPTION
[idris-mode](https://github.com/idris-hackers/idris-mode) is unhappy with Idris 2.

I get this error because the port is displayed before listening on the socket:
```
Debugger entered--Lisp error: (file-error "make client process failed" "Connection refused" :name "Idris IDE support" :buffer "*idris-connection*" :host "127.0.0.1" :service 38398 :nowait nil :tls-parameters nil)
  make-network-process(:name "Idris IDE support" :buffer "*idris-connection*" :host "127.0.0.1" :service 38398 :nowait nil :tls-parameters nil)
  open-network-stream("Idris IDE support" "*idris-connection*" "127.0.0.1" 38398)
...
```

Still doesn't make it usable though, but that's a first simple step :)