### PR TITLE
Make it a little easier to debug IDE mode

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -231,7 +231,7 @@ loop
                            processCatch cmd
                            loop 
                       Nothing => 
-                        do printError "Unrecognised command"
+                        do printError ("Unrecognised command: " ++ show sexp)
                            loop
   where
     updateOutput : Integer -> Core ()


### PR DESCRIPTION
Following #53, I get an unhelpful (for me, because I don't know much about the protocol itself) "Unrecognised command". Fortunately `SExp` implements `Show`, so should we display the command?

Example from Emacs/idris-mode:
```
00003d(:return (:error "Unrecognised command: (:version 3)" ()) 2)
```