### PR TITLE
Run individual tests (Fixes #23)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ clean-libs:
 
 test:
 	idris --build tests.ipkg
-	make -C tests only=$(only)
+	@make -C tests only=$(only)
 
 install: all install-exec install-libs
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ clean-libs:
 
 test:
 	idris --build tests.ipkg
-	make -C tests
+	make -C tests only=$(only)
 
 install: all install-exec install-libs
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -70,10 +70,10 @@ fail err
     = do putStrLn err
          exitWith (ExitFailure 1)
 
-runTest : String -> String -> String -> IO Bool
-runTest dir prog test
-    = do chdir (dir ++ "/" ++ test)
-         putStr $ dir ++ "/" ++ test ++ ": "
+runTest : String -> String -> IO Bool
+runTest prog testPath
+    = do chdir testPath
+         putStr $ testPath ++ ": "
          system $ "sh ./run " ++ prog ++ " | tr -d '\\r' > output"
          Right out <- readFile "output"
                | Left err => do print err
@@ -106,23 +106,39 @@ findChez
             Nothing => firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
                                     x <- ["scheme", "chez", "chezscheme9.5"]]
 
+runChezTests : String -> List String -> IO (List Bool)
+runChezTests prog tests
+    = do chexec <- findChez
+         maybe (do putStrLn "Chez Scheme not found"
+                   pure [])
+               (\c => do putStrLn $ "Found Chez Scheme at " ++ c
+                         traverse (runTest prog) tests)
+               chexec
+
 main : IO ()
 main
-    = do [_, idris2] <- getArgs
-              | _ => do putStrLn "Usage: runtests [ttimp path]"
-         ttimps <- traverse (runTest "ttimp" idris2) ttimpTests
-         idrs <- traverse (runTest "idris2" idris2) idrisTests
-         typedds <- traverse (runTest "typedd-book" idris2) typeddTests
-         chexec <- findChez
-         chezs <- maybe (do putStrLn "Chez Scheme not found"
-                            pure [])
-                        (\c => do putStrLn $ "Found Chez Scheme at " ++ c
-                                  traverse (runTest "chez" idris2) chezTests)
-                        chexec
-         let res = ttimps ++ typedds ++ idrs ++ chezs
+    = do args <- getArgs
+         let (_ :: idris2 :: _) = args
+              | _ => do putStrLn "Usage: runtests <idris2 path> [--only <name>]"
+         let filterTests = case drop 2 args of
+              ("--only" :: onlyName :: _) => filter (\testName => isInfixOf onlyName testName)
+              _ => id
+         let filteredNonCGTests =
+              filterTests $ concat [testPaths "ttimp" ttimpTests,
+                                    testPaths "idris2" idrisTests,
+                                    testPaths "typedd-book" typeddTests]
+         let filteredChezTests = filterTests (testPaths "chez" chezTests)
+         nonCGTestRes <- traverse (runTest idris2) filteredNonCGTests
+         chezTestRes <- if length filteredChezTests > 0
+              then runChezTests idris2 filteredChezTests
+              else pure []
+         let res = nonCGTestRes ++ chezTestRes
          putStrLn (show (length (filter id res)) ++ "/" ++ show (length res) 
                        ++ " tests successful")
          if (any not res)
             then exitWith (ExitFailure 1)
             else exitWith ExitSuccess
+    where
+         testPaths : String -> List String -> List String
+         testPaths dir tests = map (\test => dir ++ "/" ++ test) tests
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 IDRIS2 = ../../../idris2
 
 test:
-	../runtests $(IDRIS2)
+	../runtests $(IDRIS2) --only $(only)
 
 clean:
 	find . -name '*.ibc' | xargs rm -f

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 IDRIS2 = ../../../idris2
 
 test:
-	../runtests $(IDRIS2) --only $(only)
+	@../runtests $(IDRIS2) --only $(only)
 
 clean:
 	find . -name '*.ibc' | xargs rm -f

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+Tests
+=====
+
+*Note: The commands listed in this section should be run from the repository's root folder.*
+
+Run all tests: `make test`
+
+To run only a subset of the tests use: `make test only=NAME`. `NAME` is matched against the path to each test case.
+
+Examples:
+- `make test only=chez` will run all Chez Scheme tests.
+- `make test only=ttimp/basic` will run all basic tests for `TTImp`.
+- `make test only=idris2/basic001` will run a specific test.


### PR DESCRIPTION
I added an `--only` flag to `runtests` that allows you to run only a subset of the tests. The tests are filtered using `String.isInfixOf`, so it does a partial match. Also, before filtering the tests the code will prepend the directory where the tests are located, which allows filters like `--only idris2`, `--only ttimp/basic001` etc.

I modified the Makefiles to propagate an `only` variable. Thus, to run all `chez` tests one could write: `make test only=chez`.

`make test` does still run all tests, though `make` will report that it runs the following commands:
```
make -C tests only=
../runtests ../../../idris2 --only 
```
It works because `runtests` expects another argument after `--only`, which it is not given. I tried adding an `if` around each command, but then the whole `if` was printed. I could also silence these commands by prepending `@` to the commands. Is this preferable?

Should I document this feature somewhere?