### PR TITLE
Improve RTD config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 idris2
 runtests
 
+docs/_build/
+
 libs/**/build
 tests/**/output
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,13 +35,14 @@ extensions = [
     'sphinx.ext.todo',
 #    'sphinx.ext.pngmath', # imgmath is not supported on readthedocs.
     'sphinx.ext.ifconfig',
+    'recommonmark'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ['.rst','.md']
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
+ Sphinx can read CommonMark formatted files, so let us allow that capability.
+ Improve .gitignore to ignore sphinx build directories.