### PR TITLE
Print expected and given output when test fails.

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -83,9 +83,15 @@ runTest prog testPath
          Right exp <- readFile "expected"
                | Left err => do print err
                                 pure False
+
          if (out == exp)
             then putStrLn "success"
-            else putStrLn "FAILURE"
+            else do
+              putStrLn "FAILURE"
+              putStrLn "Expected:"
+              printLn exp
+              putStrLn "Given:"
+              printLn out
          chdir "../.."
          pure (out == exp)
 


### PR DESCRIPTION
Useful when looking to diagnose tests that fail.