### PR TITLE
Add output file flag (-o) to CLI

### DIFF
--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -23,6 +23,8 @@ data CLOpt
   =
    ||| Only typecheck the given file
   CheckOnly |
+   ||| The output file from the code generator
+  OutputFile String |
    ||| Execute a given function after checking the source file
   ExecFn String |
    ||| Use a specific code generator (default chez)
@@ -67,6 +69,8 @@ record OptDesc where
 options : List OptDesc
 options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Exit after checking source file"),
+           MkOpt ["--output", "-o"] ["file"] (\f => [OutputFile f, Quiet])
+              (Just "Specify output file"),
            MkOpt ["--exec", "-x"] ["name"] (\f => [ExecFn f, Quiet])
               (Just "Execute function after checking source file"),
            MkOpt ["--no-prelude"] [] [NoPrelude]

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -56,8 +56,13 @@ postOptions : {auto c : Ref Ctxt Defs} ->
               {auto u : Ref UST UState} ->
               {auto s : Ref Syn SyntaxInfo} ->
               {auto m : Ref MD Metadata} ->
+              {auto o : Ref ROpts REPLOpts} ->
               List CLOpt -> Core Bool
 postOptions [] = pure True
+postOptions (OutputFile outfile :: rest)
+    = do compileExp (PRef (MkFC "(script)" (0, 0) (0, 0)) (UN "main")) outfile
+         postOptions rest
+         pure False
 postOptions (ExecFn str :: rest) 
     = do execExp (PRef (MkFC "(script)" (0, 0) (0, 0)) (UN str))
          postOptions rest


### PR DESCRIPTION
Adds `--output`/`-o` to Idris 2's CLI. This flag will compile and generate output file in the current directory.

`idris2 -o <outfile> Test.idr` is the same as performing `:c <outfile> main` from the REPL. Note that this flag expects the entrypoint function to be named `main`. This is similar to what Idris 1 does.

Have tested that it works with Chez and Racket (but not Chicken).