### PR TITLE
Ignore empty lines in REPL

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1395,9 +1395,8 @@ editCmd
          pure (MakeWith (fromInteger line) n)
   <|> fatalError "Unrecognised command"
 
-export
-command : Rule REPLCmd
-command
+nonEmptyCommand : Rule REPLCmd
+nonEmptyCommand
     = do symbol ":"; replCmd ["t", "type"]
          tm <- expr pdef "(interactive)" init
          pure (Check tm)
@@ -1445,3 +1444,9 @@ command
   <|> do tm <- expr pdef "(interactive)" init
          pure (Eval tm)
 
+export
+command : EmptyRule REPLCmd
+command
+    = do eoi
+         pure NOP
+  <|> nonEmptyCommand

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -551,6 +551,8 @@ process (Editing cmd)
 process Quit 
     = do iputStrLn "Bye for now!"
          pure False
+process NOP
+    = pure True
 
 processCatch : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->
@@ -619,7 +621,10 @@ repl
          inp <- coreLift getLine
          end <- coreLift $ fEOF stdin
          if end
-            then iputStrLn "Bye for now!"
+            then do
+                    -- start a new line in REPL mode (not relevant in IDE mode)
+                    coreLift $ putStrLn ""
+                    iputStrLn "Bye for now!"
             else if !(interpret inp)
                     then repl
                     else pure ()

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -280,6 +280,7 @@ data REPLCmd : Type where
      Metavars : REPLCmd
      Editing : EditCmd -> REPLCmd
      Quit : REPLCmd
+     NOP : REPLCmd
 
 public export
 record Import where


### PR DESCRIPTION
This ignores empty lines in the REPL and doesn't show a parse error on CTRL+D/EOF anymore.
I've implemented this by adding a `NOP` variant to `REPLCmd` similar to how it was done in Idris 1 (as far as I understand :)). Is this the way to do this?
