### PR TITLE
Tidy up REPL shutdown

### DIFF
--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -549,8 +549,7 @@ process (Editing cmd)
          setPPrint ppopts
          pure True
 process Quit 
-    = do iputStrLn "Bye for now!"
-         pure False
+    = pure False
 
 processCatch : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->
@@ -574,11 +573,17 @@ processCatch cmd
                            coreLift (putStrLn !(display err))
                            pure True)
 
-parseRepl : String -> Either ParseError REPLCmd
+parseEmptyCmd : EmptyRule (Maybe REPLCmd)
+parseEmptyCmd = eoi *> (pure Nothing)
+
+parseCmd : Rule (Maybe REPLCmd)
+parseCmd = do c <- command; eoi; pure $ Just c
+
+parseRepl : String -> Either ParseError (Maybe REPLCmd)
 parseRepl inp
     = case fnameCmd [(":load ", Load), (":l ", Load), (":cd ", CD)] inp of
-           Nothing => runParser inp (do c <- command; eoi; pure c)
-           Just cmd => Right cmd
+           Nothing => runParser inp (parseEmptyCmd <|> parseCmd)
+           Just cmd => Right $ Just cmd
   where
     -- a right load of hackery - we can't tokenise the filename using the
     -- ordinary parser. There's probably a better way...
@@ -603,7 +608,8 @@ interpret inp
     = case parseRepl inp of
            Left err => do printError (show err)
                           pure True
-           Right cmd => processCatch cmd
+           Right Nothing => pure True
+           Right (Just cmd) => processCatch cmd
 
 export
 repl : {auto c : Ref Ctxt Defs} ->
@@ -617,12 +623,13 @@ repl
          opts <- get ROpts
          coreLift (putStr (prompt (evalMode opts) ++ showSep "." (reverse ns) ++ "> "))
          inp <- coreLift getLine
+         repeat <- interpret inp
          end <- coreLift $ fEOF stdin
-         if end
-            then iputStrLn "Bye for now!"
-            else if !(interpret inp)
-                    then repl
-                    else pure ()
+         if repeat && not end
+           then repl 
+           else 
+             do coreLift $ putStrLn "Bye for now!"
+                pure ()
 
   where
     prompt : REPLEval -> String


### PR DESCRIPTION
Previously, shutting down the REPL was hacky. Piping a file as input to the REPL or pressing Ctrl-D in the REPL caused a parse error. By adding an empty prompt case to the interpret function and modifying the end of file logic this PR keeps this error from happening.