### PR TITLE
Fixed #!/usr/bin/env shebang for Chez backend

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -29,7 +29,7 @@ findChez
             Just n => pure n
             Nothing => do e <- firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
                                     x <- ["scheme", "chez", "chezscheme9.5"]]
-                          maybe (pure "/usr/bin/env scheme") pure e
+                          maybe (pure "/usr/bin/env -S scheme") pure e
 
 -- Given the chez compiler directives, return a list of pairs of:
 --   - the library file name


### PR DESCRIPTION
On NixOS, idris2 can't find scheme in the usual locations, so it
defaults to generating the following shebang:

    #!/usr/bin/env scheme --script

The `env` program interprets `scheme --script` as one monolithic
command, instead of as a command and one argument.

    /usr/bin/env: ‘scheme --script’: No such file or directory
    /usr/bin/env: use -[v]S to pass options in shebang lines

The -S flag forces `env` to split on whitespace in the intuitive
manner.