### PR TITLE
remove another message to make network tests more reliable

### DIFF
--- a/libs/network/Echo.idr
+++ b/libs/network/Echo.idr
@@ -33,12 +33,6 @@ runServer = do
       putStrLn ("Received: " ++ str)
       Right n <- send s ("echo: " ++ str)
         | Left err => putStrLn ("Server failed to send data with error: " ++ show err)
-      -- This might be printed either before or after the client prints
-      -- what it's received, and I think there's enough to check it's
-      -- working without this message so I've removed it. If you disagree,
-      -- please put it back, but also please make sure it's synchronised
-      -- such that the messages are always printed in the same order. - EB
-      -- putStrLn ("Server sent " ++ show n ++ " bytes")
       pure ()
 
 runClient : Port -> IO ()
@@ -51,9 +45,10 @@ runClient serverPort = do
     else do
       Right n <- send sock ("hello world!")
         | Left err => putStrLn ("Client failed to send data with error: " ++ show err)
-      putStrLn ("Client sent " ++ show n ++ " bytes")
       Right (str, _) <- recv sock 1024
         | Left err => putStrLn ("Client failed to receive on socket with error: " ++ show err)
+      -- assuming that stdout buffers get flushed in between system calls, this is "guaranteed"
+      -- to be printed after the server prints its own message
       putStrLn ("Received: " ++ str)
 
 main : IO ()

--- a/libs/network/expected
+++ b/libs/network/expected
@@ -1,3 +1,2 @@
-Client sent 12 bytes
 Received: hello world!
 Received: echo: hello world!


### PR DESCRIPTION
I noticed that there is still a race condition in the ordering of the messages between client and server, I _think_ this time it's pretty safe... (famous last words)