### PR TITLE
Add some missing public exports

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -180,7 +180,7 @@ merge = mergeBy compare
 ||| ```idris example
 ||| reverse [1,2,3,4]
 ||| ```
-export
+public export
 reverse : Vect len elem -> Vect len elem
 reverse xs = go [] xs
   where go : Vect n elem -> Vect m elem -> Vect (n+m) elem

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -17,7 +17,7 @@ data Vect : (len : Nat) -> (elem : Type) -> Type where
 -- Hints for interactive editing
 %name Vect xs,ys,zs,ws
 
-export
+public export
 length : (xs : Vect len elem) -> Nat
 length [] = 0
 length (x::xs) = 1 + length xs

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -1308,9 +1308,11 @@ Cast Nat Double where
 -- RANGES --
 ------------
 
+public export
 countFrom : n -> (n -> n) -> Stream n
 countFrom start diff = start :: countFrom (diff start) diff
 
+public export
 partial
 takeUntil : (n -> Bool) -> Stream n -> List n
 takeUntil p (x :: xs)


### PR DESCRIPTION
The following code is currently broken in Idris 2 but works in Idris 1:
```idris

bar : List Integer
bar = [0..9]

foo_works: Vect (length Main.bar) Integer
foo_works = fromList bar

foo_broken : Vect 10 Integer
foo_broken = fromList bar

works : length (the (List Nat) (1 :: 2 :: [])) = 2
works = Refl

doesNotWork : length Main.bar = 10
doesNotWork = Refl
```
Error message:
```
1/1: Building integerToNatProblem (integerToNatProblem.idr)
integerToNatProblem.idr:18:14--19:1:While processing right hand side of Main.foo_broken at integerToNatProblem.idr:18:1--19:1:
Can't solve constraint between:
	length bar
and
	S (assert_total (integerToNat (prim__sub_Integer 10 (fromInteger 1))))
```

Looks like this got stuck because `Vect.length` and `Prelude.countFrom` and `Prelude.takeUntil` (which are used in the `Prelude.rangeFromTo` implementation) were not `public export`.

I'm not sure whether `Prelude.countFrom` and `Prelude.takeUntil` are intended to be exposed though?