### PR TITLE
Bugfix #115

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -883,6 +883,16 @@ resolveName n
        setCtxt gam'
        pure i
 
+export
+addName : {auto c : Ref Ctxt Defs} ->
+          Name -> Core Int
+addName (Resolved idx) = pure idx
+addName n
+  = do defs <- get Ctxt
+       (i, gam') <- newEntry n (gamma defs)
+       setCtxt gam'
+       pure i
+
 -- Call this before trying alternative elaborations, so that updates to the
 -- context are put in the staging area rather than writing over the mutable
 -- array of definitions.

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -16,7 +16,7 @@ import TTImp.TTImp
 
 export
 checkLocal : {vars : _} ->
-{auto c : Ref Ctxt Defs} ->
+             {auto c : Ref Ctxt Defs} ->
              {auto m : Ref MD Metadata} ->
              {auto u : Ref UST UState} ->
              {auto e : Ref EST (EState vars)} ->


### PR DESCRIPTION
Add an 'addName' function to Contex.idr interface for adding a new
name to the context.

Modify checkLocal to always add the newly bound names to the context

The list of binding occurrences we iterate over must not have
duplicates, so we remove them with nub.