### PR TITLE
Fix --clean option

### DIFF
--- a/src/Data/StringMap.idr
+++ b/src/Data/StringMap.idr
@@ -11,16 +11,16 @@ Key = String
 
 private
 data Tree : Nat -> Type -> Type where
-  Leaf : Key -> v -> Tree Z v 
-  Branch2 : Tree n v -> Key -> Tree n v -> Tree (S n) v 
-  Branch3 : Tree n v -> Key -> Tree n v -> Key -> Tree n v -> Tree (S n) v 
+  Leaf : Key -> v -> Tree Z v
+  Branch2 : Tree n v -> Key -> Tree n v -> Tree (S n) v
+  Branch3 : Tree n v -> Key -> Tree n v -> Key -> Tree n v -> Tree (S n) v
 
 branch4 :
   Tree n v -> Key ->
   Tree n v -> Key ->
   Tree n v -> Key ->
   Tree n v ->
-  Tree (S (S n)) v 
+  Tree (S (S n)) v
 branch4 a b c d e f g =
   Branch2 (Branch2 a b c) d (Branch2 e f g)
 
@@ -260,7 +260,7 @@ export
 values : StringMap v -> List v
 values = map snd . toList
 
-treeMap : (a -> b) -> Tree n a -> Tree n b 
+treeMap : (a -> b) -> Tree n a -> Tree n b
 treeMap f (Leaf k v) = Leaf k (f v)
 treeMap f (Branch2 t1 k t2) = Branch2 (treeMap f t1) k (treeMap f t2)
 treeMap f (Branch3 t1 k1 t2 k2 t3)
@@ -292,6 +292,10 @@ merge = mergeWith (<+>)
 export
 mergeLeft : StringMap v -> StringMap v -> StringMap v
 mergeLeft x y = mergeWith const x y
+
+export
+Show v => Show (StringMap v) where
+  show m = show $ map {b=String} (\(k,v) => k ++ "->" ++ show v) $ toList m
 
 -- TODO: is this the right variant of merge to use for this? I think it is, but
 -- I could also see the advantages of using `mergeLeft`. The current approach is

--- a/src/Data/StringTrie.idr
+++ b/src/Data/StringTrie.idr
@@ -11,11 +11,14 @@ import Data.StringMap
 record StringTrie a where
   constructor MkStringTrie
   node : These a (StringMap (StringTrie a))
-  
-Functor StringTrie where 
+
+Show a => Show (StringTrie a) where
+  show (MkStringTrie node) = assert_total $ show node
+
+Functor StringTrie where
   map f (MkStringTrie node) = MkStringTrie $ assert_total $ bimap f (map (map f)) node
 
-empty : StringTrie a 
+empty : StringTrie a
 empty = MkStringTrie $ That empty
 
 singleton : List String -> a -> StringTrie a
@@ -24,32 +27,33 @@ singleton (k::ks) v = MkStringTrie $ That $ singleton k (singleton ks v)
 
 -- insert using supplied function to resolve clashes
 insertWith : List String -> (Maybe a -> a) -> StringTrie a -> StringTrie a
-insertWith []      f (MkStringTrie nd) = 
+insertWith []      f (MkStringTrie nd) =
   MkStringTrie $ these (This . f . Just) (Both (f Nothing)) (Both . f . Just) nd
-insertWith (k::ks) f (MkStringTrie nd) = 
+insertWith (k::ks) f (MkStringTrie nd) =
   MkStringTrie $ these (\x => Both x (singleton k end)) (That . rec) (\x => Both x . rec) nd
   where
   end : StringTrie a
   end = singleton ks (f Nothing)
   rec : StringMap (StringTrie a) -> StringMap (StringTrie a)
-  rec sm = maybe (insert k end sm) (\tm => insert k (insertWith ks f tm) sm) (lookup k sm) 
+  rec sm = maybe (insert k end sm) (\tm => insert k (insertWith ks f tm) sm) (lookup k sm)
 
 insert : List String -> a -> StringTrie a -> StringTrie a
 insert ks v = insertWith ks (const v)
 
--- fold the trie in a depth-first fashion performing monadic actions on values, then keys  
+-- fold the trie in a depth-first fashion performing monadic actions on values, then keys
+-- note that for `Both` the action on node values will be performed first because of `bitraverse` implementation
 foldWithKeysM : (Monad m, Monoid b) => (List String -> m b) -> (List String -> a -> m b) -> StringTrie a -> m b
-foldWithKeysM {a} {m} {b} fk fv = go [] 
-  where 
+foldWithKeysM {a} {m} {b} fk fv = go []
+  where
   go : List String -> StringTrie a -> m b
-  go as (MkStringTrie nd) = 
-    bifold <$> bitraverse 
-                (fv as) 
-                (\sm => foldlM 
-                          (\x, (k, vs) => do let as' = as ++ [k]
-                                             y <- assert_total $ go as' vs
-                                             z <- fk as'
+  go ks (MkStringTrie nd) =
+    bifold <$> bitraverse
+                (fv ks)
+                (\sm => foldlM
+                          (\x, (k, vs) => do let ks' = ks++[k]
+                                             y <- assert_total $ go ks' vs
+                                             z <- fk ks'
                                              pure $ x <+> y <+> z)
-                          neutral 
-                          (toList sm)) 
-                nd 
+                          neutral
+                          (toList sm))
+                nd

--- a/src/Data/These.idr
+++ b/src/Data/These.idr
@@ -3,7 +3,7 @@ module Data.These
 %access public export
 %default total
 
-data These a b = This a | That b | Both a b 
+data These a b = This a | That b | Both a b
 
 fromEither : Either a b -> These a b
 fromEither = either This That
@@ -18,6 +18,11 @@ bimap f g (This a)   = This (f a)
 bimap f g (That b)   = That (g b)
 bimap f g (Both a b) = Both (f a) (g b)
 
+(Show a, Show b) => Show (These a b) where
+  showPrec d (This x)   = showCon d "This" $ showArg x
+  showPrec d (That x)   = showCon d "That" $ showArg x
+  showPrec d (Both x y) = showCon d "Both" $ showArg x ++ showArg y
+
 Functor (These a) where
   map = bimap id
 
@@ -26,10 +31,10 @@ mapFst f = bimap f id
 
 bifold : Monoid m => These m m -> m
 bifold (This a)   = a
-bifold (That b)   = b 
+bifold (That b)   = b
 bifold (Both a b) = a <+> b
 
 bitraverse : Applicative f => (a -> f c) -> (b -> f d) -> These a b -> f (These c d)
-bitraverse f g (This a)   = [| This (f a) |] 
+bitraverse f g (This a)   = [| This (f a) |]
 bitraverse f g (That b)   = [| That (g b) |]
 bitraverse f g (Both a b) = [| Both (f a) (g b) |]


### PR DESCRIPTION
This fixes two bugs:
* Build artefacts are in `ttc` subfolder as of https://github.com/edwinb/Idris2/commit/65db4fbf961cbdd36f10a9a75e7c3311b91f5585
* Namespaces were reversed at the wrong place leading to problems with nested folders

Also adds a few `Show` instances (mostly for debugging)