### PR TITLE
Add `head` and `tail` to base/Data.List.

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -140,6 +140,20 @@ export
 Uninhabited (NonEmpty []) where
   uninhabited IsNonEmpty impossible
 
+||| Get the head of a non-empty list.
+||| @ ok proof the list is non-empty
+public export
+head : (l : List a) -> {auto ok : NonEmpty l} -> a
+head [] impossible
+head (x :: xs) = x
+
+||| Get the tail of a non-empty list.
+||| @ ok proof the list is non-empty
+public export
+tail : (l : List a) -> {auto ok : NonEmpty l} -> List a
+tail [] impossible
+tail (x :: xs) = xs
+
 ||| Convert any Foldable structure to a list.
 export
 toList : Foldable t => t a -> List a


### PR DESCRIPTION
These functions use the NonEmpty predicate type in order to prove that the operation will be valid.

Implementations copied from Idris1's Prelude.List module, except without expanding the auto implicit argument.