### PR TITLE
Bugfix #133

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -62,12 +62,16 @@ record TTCFile extra where
   extraData : extra
 
 HasNames a => HasNames (List a) where
-  full c [] = pure []
-  full c (n :: ns) = pure $ !(full c n) :: !(full c ns)
+  full c ns = full_aux c [] ns
+    where full_aux : Context -> List a -> List a -> Core (List a)
+          full_aux c res [] = pure (reverse res)
+          full_aux c res (n :: ns) = full_aux c (!(full c n):: res) ns
 
-  resolved c [] = pure []
-  resolved c (n :: ns) = pure $ !(resolved c n) :: !(resolved c ns)
 
+  resolved c ns = resolved_aux c [] ns
+    where resolved_aux : Context -> List a -> List a -> Core (List a)
+          resolved_aux c res [] = pure (reverse res)
+          resolved_aux c res (n :: ns) = resolved_aux c (!(resolved c n) :: res) ns
 HasNames (Int, FC, Name) where
   full c (i, fc, n) = pure (i, fc, !(full c n))
   resolved c (i, fc, n) = pure (i, fc, !(resolved c n))

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -28,7 +28,7 @@ idrisTests
        "basic011", "basic012", "basic013", "basic014", "basic015",
        "basic016", "basic017", "basic018", "basic019", "basic020",
        "basic021", "basic022", "basic023", "basic024", "basic025",
-       "basic026", "basic027", "basic028",
+       "basic026", "basic027", "basic028", "basic029",
        "coverage001", "coverage002", "coverage003", "coverage004",
        "error001", "error002", "error003", "error004", "error005",
        "error006", "error007", "error008", "error009", "error010",

--- a/tests/idris2/basic029/Params.idr
+++ b/tests/idris2/basic029/Params.idr
@@ -1,0 +1,3 @@
+parameters (x : Nat, y : Nat)
+  add : Nat
+  add = x + y

--- a/tests/idris2/basic029/expected
+++ b/tests/idris2/basic029/expected
@@ -1,0 +1,6 @@
+1/1: Building Params (Params.idr)
+Main> S (S Z)
+Main> Z
+Main> S Z
+Main> S Z
+Main> Bye for now!

--- a/tests/idris2/basic029/input
+++ b/tests/idris2/basic029/input
@@ -1,0 +1,5 @@
+add 1 1
+add 0 0
+add 1 0
+add 0 1
+:q

--- a/tests/idris2/basic029/run
+++ b/tests/idris2/basic029/run
@@ -1,0 +1,3 @@
+$1 --no-banner Params.idr < input
+
+rm -rf build


### PR DESCRIPTION
turn `HasNames (List a)` tail-recursive 

The problem seems to be a non-tail-recursive traversal of the huge proof terms I'm constructing.
Specifically the `HasNames` implementation for `List a` in `Core/Binary.idr` was not tail recursive.
Making it tail recursive makes the stack overflow go away.