### PR TITLE
Tail recursive lists

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -85,7 +85,7 @@ span p (x::xs) =
 
 public export
 break : (a -> Bool) -> List a -> (List a, List a)
-break p = span (not . p)
+break p xs = span (not . p) xs
 
 public export
 split : (a -> Bool) -> List a -> List (List a)
@@ -159,6 +159,18 @@ export
 toList : Foldable t => t a -> List a
 toList = foldr (::) []
 
+||| Prefix every element in the list with the given element
+|||
+||| ```idris example
+||| with List (mergeReplicate '>' ['a', 'b', 'c', 'd', 'e'])
+||| ```
+|||
+export
+mergeReplicate : a -> List a -> List a
+mergeReplicate sep []      = []
+mergeReplicate sep (y::ys) = sep :: y :: mergeReplicate sep ys
+
+
 ||| Insert some separator between the elements of a list.
 |||
 ||| ````idris example
@@ -168,11 +180,7 @@ toList = foldr (::) []
 export
 intersperse : a -> List a -> List a
 intersperse sep []      = []
-intersperse sep (x::xs) = x :: intersperse' sep xs
-  where
-    intersperse' : a -> List a -> List a
-    intersperse' sep []      = []
-    intersperse' sep (y::ys) = sep :: y :: intersperse' sep ys
+intersperse sep (x::xs) = x :: mergeReplicate sep xs
 
 ||| Apply a partial function to the elements of a list, keeping the ones at which
 ||| it is defined.
@@ -212,7 +220,7 @@ mergeBy order (x::xs) (y::ys) =
 ||| Merge two sorted lists using the default ordering for the type of their elements.
 export
 merge : Ord a => List a -> List a -> List a
-merge = mergeBy compare
+merge left right = mergeBy compare left right
 
 ||| Sort a list using some arbitrary comparison predicate.
 |||

--- a/libs/base/Data/List/TailRec.idr
+++ b/libs/base/Data/List/TailRec.idr
@@ -1,0 +1,394 @@
+||| Contains:
+|||
+||| 1. Tail recursive versions of the list processing functions from
+|||    Data.List.
+||| 
+||| 2. Extensional equality proofs that these variants are
+|||    (extensionally) equivalent to their non-tail-recursive
+|||    counterparts.
+|||
+||| Note:
+|||
+||| 1. Written in one sitting, feel free to refactor
+||| 
+||| 2. The proofs below also work on non-publicly exported
+|||    definitions.  This could be due to a bug, and will need to be
+|||    moved elsewhere if it's fixed.
+module Data.List.TailRec
+
+import Syntax.PreorderReasoning
+import Syntax.WithProof
+
+import Data.List
+import Data.Vect
+import Data.Nat
+
+length_aux : List a -> Nat -> Nat
+length_aux [] len = len
+length_aux (_::xs) len = length_aux xs (S len)
+
+export
+length : List a -> Nat
+length xs = length_aux xs Z
+
+export
+length_ext : (xs : List a) -> Data.List.length xs = Data.List.TailRec.length xs
+length_ext xs = Calculate [
+  Data.List.length xs
+  ==| sym (plusZeroRightNeutral (Data.List.length xs)),
+  Data.List.length xs + 0
+  ==| lemma 0 xs,
+  Data.List.TailRec.length_aux xs 0
+  ==| Refl,
+  Data.List.TailRec.length xs
+  ==| QED
+  ]
+  where
+    lemma : (n : Nat) -> (xs : List a) -> 
+            Data.List.length xs + n  = length_aux xs n
+    lemma n [] = Refl
+    lemma n (_ :: xs) = 
+      let length_xs : Nat
+          length_xs = Data.List.length xs in
+      Calculate [
+      1 + (length_xs + n)
+      -- Hopefully we could Frex these two steps one day
+      ==| plusAssociative 1 length_xs n ,
+      (1 + length_xs) + n
+      ==| cong (+n) (plusCommutative 1 length_xs) ,
+      (length_xs + 1) + n
+      ==| sym (plusAssociative length_xs 1 n),
+      (length_xs) + (1 + n)
+      ==| lemma (1 + n) xs,
+      length_aux xs (1 + n)
+      ==| QED
+    ]
+
+take_aux : Nat -> List a -> List a -> List a
+take_aux Z     xs        acc = reverseOnto [] acc
+take_aux (S n) []        acc = reverseOnto [] acc
+take_aux (S n) (x :: xs) acc = take_aux n xs (x :: acc)
+        
+export 
+take : Nat -> List a -> List a
+take n xs = take_aux n xs []
+
+export
+take_ext : 
+  (n : Nat) -> (xs : List a) ->
+     Data.List.take n xs = Data.List.TailRec.take n xs
+take_ext n xs = Calculate [
+  Data.List.take n xs
+  ==| Refl ,
+  reverse [] ++ (Data.List.take n xs)
+  ==| sym (revOnto (Data.List.take n xs) []) ,
+  reverseOnto (Data.List.take n xs) []
+  ==| sym (lemma n xs []) ,
+  take_aux n xs []
+  ==| QED
+  ]
+  where
+    lemma : (n : Nat) -> (xs, acc : List a) -> 
+            take_aux n xs acc =  reverseOnto (Data.List.take n xs) acc
+    lemma Z     xs      acc = Refl
+    lemma (S n) []      acc = Refl
+    lemma (S n) (x::xs) acc = lemma n xs (x :: acc) 
+
+
+span_aux : (a -> Bool) -> List a -> List a -> (List a, List a)
+span_aux p []      acc = (reverseOnto [] acc, [])
+span_aux p (x::xs) acc = 
+  if p x then
+    Data.List.TailRec.span_aux p xs (x :: acc)
+  else
+    (reverseOnto [] acc, x::xs)
+    
+export
+span : (a -> Bool) -> List a -> (List a, List a)
+span p xs = span_aux p xs []
+
+coe : (f : (i : a) -> Type) -> i = i' -> f i -> f i'
+coe f Refl x = x
+
+span_aux_ext : (p : a -> Bool) -> (xs, acc : List a) -> 
+  (reverseOnto (fst $ Data.List.span p xs) acc, snd $ Data.List.span p xs)
+  =
+  span_aux p xs acc
+span_aux_ext p []      acc = Refl
+-- This is disgusting. Please teach me a better way.
+span_aux_ext p (x::xs) acc with (@@(p x), @@(Data.List.span p xs))
+ span_aux_ext p (x::xs) acc | ((True ** px_tru), ((pre, rest)**dl_pf)) = 
+   rewrite px_tru in 
+   rewrite dl_pf in 
+   let u = span_aux_ext p xs (x::acc) in
+   coe (\u => (reverseOnto (x :: fst u) acc, snd u) = 
+               Data.List.TailRec.span_aux p xs (x :: acc)) dl_pf u 
+ span_aux_ext p (x::xs) acc | ((False**px_fls), ((pre,rest)**dl_pf)) = 
+   rewrite px_fls in
+   Refl
+
+export
+span_ext : (p : a -> Bool) -> (xs : List a) -> 
+  Data.List.span p xs = Data.List.TailRec.span p xs
+span_ext p xs with (@@(Data.List.span p xs))
+  span_ext p xs |  ((pre, rest) ** pf) = 
+    rewrite pf in 
+    let u = span_aux_ext p xs [] in 
+    coe (\u => (fst u, snd u) = span_aux p xs []) pf u 
+
+export
+break : (a -> Bool) -> List a -> (List a, List a)
+break p xs = Data.List.TailRec.span (not . p) xs
+
+export
+break_ext : (p : a -> Bool) -> (xs : List a) ->
+  Data.List.break p xs = Data.List.TailRec.break p xs
+break_ext p xs = span_ext (not . p) xs
+
+splitOnto : List (List a) -> (a -> Bool) -> List a -> List (List a)
+splitOnto acc p xs = 
+  case Data.List.break p xs of
+    (chunk, []       ) => reverseOnto [chunk] acc
+    (chunk, (c::rest)) => splitOnto (chunk::acc) p rest
+
+export    
+split : (a -> Bool) -> List a -> List (List a)
+split p xs = splitOnto [] p xs
+
+splitOnto_ext : (acc : List (List a)) -> (p : a -> Bool) -> (xs : List a) ->
+              reverseOnto (Data.List.split p xs) acc
+              = Data.List.TailRec.splitOnto acc p xs
+splitOnto_ext  acc p xs with (@@(Data.List.break p xs))
+ splitOnto_ext acc p xs | ((chunk,  []    )**pf) = 
+   rewrite pf in 
+   Refl
+ splitOnto_ext acc p xs | ((chunk, c::rest)**pf) = 
+   rewrite pf in
+   rewrite splitOnto_ext (chunk::acc) p rest in
+   Refl
+
+export
+split_ext : (p : a -> Bool) -> (xs : List a) ->
+  Data.List.split p xs = Data.List.TailRec.split p xs
+split_ext p xs = splitOnto_ext [] p xs
+
+
+splitAtOnto : List a -> (n : Nat) -> (xs : List a) -> (List a, List a)
+splitAtOnto acc Z     xs      = (reverseOnto [] acc, xs)
+splitAtOnto acc (S n) []      = (reverseOnto [] acc, [])
+splitAtOnto acc (S n) (x::xs) = splitAtOnto (x::acc) n xs
+
+export
+splitAt : (n : Nat) -> (xs : List a) -> (List a, List a)
+splitAt n xs = splitAtOnto [] n xs
+
+splitAtOnto_ext : (acc : List a) -> (n : Nat) -> (xs : List a) ->
+  (reverseOnto (fst $ Data.List.splitAt n xs) acc, snd $ Data.List.splitAt n xs)
+  = splitAtOnto acc n xs
+splitAtOnto_ext  acc Z     xs      = Refl
+splitAtOnto_ext  acc (S n) []      = Refl
+splitAtOnto_ext  acc (S n) (x::xs) with (@@(Data.List.splitAt n xs))
+ splitAtOnto_ext acc (S n) (x::xs) | ((tk, dr)**pf) = 
+   rewrite pf in
+   let u = splitAtOnto_ext (x::acc) n xs in
+   coe (\u => (reverseOnto (x :: fst u) acc, snd u) = 
+                      splitAtOnto (x :: acc) n xs) pf u 
+
+export
+splitAt_ext : (n : Nat) -> (xs : List a) -> 
+  Data.List.splitAt n xs = 
+  Data.List.TailRec.splitAt n xs 
+splitAt_ext  n xs with (@@(Data.List.splitAt n xs))
+ splitAt_ext n xs | ((tk, dr)**pf) = 
+   rewrite pf in
+   rewrite sym $ splitAtOnto_ext [] n xs in
+   rewrite pf in 
+   Refl
+
+partitionOnto : List a -> List a -> (a -> Bool) -> List a -> (List a, List a)
+partitionOnto lfts rgts p []      = (reverseOnto [] lfts, reverseOnto [] rgts)
+partitionOnto lfts rgts p (x::xs) = 
+  if p x then
+    partitionOnto (x :: lfts)     rgts  p xs
+  else
+    partitionOnto       lfts  (x::rgts) p xs
+    
+export
+partition : (a -> Bool) -> List a -> (List a, List a)
+partition p xs = partitionOnto [] [] p xs
+
+partitionOnto_ext : (lfts, rgts : List a) -> (p : a -> Bool) -> (xs : List a) -> 
+  (reverseOnto (fst $ Data.List.partition p xs) lfts
+  ,reverseOnto (snd $ Data.List.partition p xs) rgts) 
+  = Data.List.TailRec.partitionOnto lfts rgts p xs
+partitionOnto_ext  lfts rgts p [] = Refl
+partitionOnto_ext  lfts rgts p (x::xs) with (@@(p x), @@(Data.List.partition p xs))
+ partitionOnto_ext lfts rgts p (x::xs) | ((True **px_tru), ((dl_l, dl_r)**dl_pf))
+   = rewrite px_tru in 
+     rewrite dl_pf  in
+     rewrite px_tru in
+     let u = partitionOnto_ext (x :: lfts) rgts p xs in
+     coe (\u => (reverseOnto (x :: fst u) lfts
+                ,reverseOnto (     snd u) rgts) 
+                = partitionOnto (x :: lfts) rgts p xs) dl_pf u
+
+ partitionOnto_ext lfts rgts p (x::xs) | ((False**px_fls), ((dl_l, dl_r)**dl_pf))
+   = rewrite px_fls in
+     rewrite dl_pf  in
+     rewrite px_fls in 
+     let u = partitionOnto_ext lfts (x :: rgts) p xs in
+     coe (\u => (reverseOnto (     fst u) lfts
+                ,reverseOnto (x :: snd u) rgts) 
+                = partitionOnto lfts (x::rgts) p xs) dl_pf u
+
+mergeReplicate_aux : a -> List a -> List a -> List a
+mergeReplicate_aux sep []      acc = reverseOnto [] acc
+mergeReplicate_aux sep (x::xs) acc = mergeReplicate_aux sep xs (x :: sep :: acc)
+
+mergeReplicate_ext : (sep : a) -> (xs : List a) -> (acc : List a) ->
+                   mergeReplicate_aux sep xs acc = 
+                   reverseOnto (mergeReplicate sep xs) acc
+mergeReplicate_ext sep []      acc = Refl
+mergeReplicate_ext sep (x::xs) acc = Calculate [
+  mergeReplicate_aux sep xs (x :: sep :: acc)
+  ==| mergeReplicate_ext sep xs (x :: sep :: acc) ,
+  reverseOnto (sep :: x :: mergeReplicate sep xs) acc
+  ==| QED
+  ]
+
+export
+intersperse : a -> List a -> List a
+intersperse sep []      = []
+intersperse sep (y::ys) = y :: mergeReplicate_aux sep ys []
+  
+export
+intersperse_ext : (sep : a) -> (xs : List a) -> 
+              Data.List.intersperse sep xs = 
+              Data.List.TailRec.intersperse sep xs
+intersperse_ext sep [] = Refl
+intersperse_ext sep (y::ys) = cong (y::) (sym $ mergeReplicate_ext sep ys [])
+
+mapMaybeOnto : List b -> (a -> Maybe b) -> List a -> List b
+mapMaybeOnto acc f [] = reverseOnto [] acc
+mapMaybeOnto acc f (x::xs) = 
+  case f x of
+    Nothing => mapMaybeOnto acc f xs
+    Just  y => mapMaybeOnto (y :: acc) f xs
+
+export
+mapMaybe : (a -> Maybe b) -> List a -> List b
+mapMaybe f xs = mapMaybeOnto [] f xs
+
+mapMaybeOnto_ext : (acc : List b) -> (f : a -> Maybe b) -> (xs : List a) ->
+  reverseOnto (Data.List.mapMaybe f xs) acc
+  = 
+  mapMaybeOnto acc f xs
+mapMaybeOnto_ext  acc f []                = Refl
+mapMaybeOnto_ext  acc f (x::xs) with (f x)
+ mapMaybeOnto_ext acc f (x::xs) | Nothing = mapMaybeOnto_ext acc f xs
+ mapMaybeOnto_ext acc f (x::xs) | Just  y = mapMaybeOnto_ext (y :: acc) f xs
+ 
+export 
+mapMaybe_ext : (f : a -> Maybe b) -> (xs : List a) -> 
+  Data.List.mapMaybe f xs = Data.List.TailRec.mapMaybe f xs
+mapMaybe_ext f xs = mapMaybeOnto_ext [] f xs
+
+export
+sorted : Ord a => List a -> Bool
+sorted [ ] = True
+sorted [x] = True
+sorted  (x :: xs@(y :: ys)) = case (x <= y) of
+                                False => False
+                                True  => Data.List.TailRec.sorted xs
+    
+export
+sorted_ext : Ord a => (xs : List a) -> 
+  Data.List.sorted xs = Data.List.TailRec.sorted xs
+sorted_ext []  = Refl
+sorted_ext [x] = Refl
+sorted_ext  (x :: y :: ys) with (x <= y) 
+ sorted_ext (x :: y :: ys) | False = Refl
+ sorted_ext (x :: y :: ys) | True  = sorted_ext (y::ys)
+  
+mergeByOnto : List a -> (a -> a -> Ordering) -> List a -> List a -> List a
+mergeByOnto acc order []           right         = reverseOnto right acc
+mergeByOnto acc order left         []            = reverseOnto left  acc
+mergeByOnto acc order left@(x::xs) right@(y::ys) = 
+  case order x y of
+    LT => mergeByOnto (x :: acc) order xs   right
+    _  => mergeByOnto (y :: acc) order left ys
+    
+mergeByOnto_ext : (acc : List a) 
+               -> (order : a -> a -> Ordering) 
+               -> (left, right : List a) 
+               -> reverseOnto (mergeBy order left right) acc 
+                  = mergeByOnto acc order left right
+mergeByOnto_ext acc order []           right         = Refl
+mergeByOnto_ext acc order left         []            = ?bug139
+mergeByOnto_ext acc order left@(x::xs) right@(y::ys) with (order x y)
+ mergeByOnto_ext acc order left@(x::xs) right@(y::ys) | LT = 
+                           mergeByOnto_ext (x :: acc) order xs (y::ys)
+ -- We need to exhaust the two other cases explicitly to convince the
+ -- typecheker. See #140
+ mergeByOnto_ext acc order left@(x::xs) right@(y::ys) | EQ = 
+                           mergeByOnto_ext (y :: acc) order (x::xs) ys
+ mergeByOnto_ext acc order left@(x::xs) right@(y::ys) | GT = 
+                           mergeByOnto_ext (y :: acc) order (x::xs) ys
+
+export
+mergeBy : (a -> a -> Ordering) -> List a -> List a -> List a
+mergeBy order left right = mergeByOnto [] order left right
+
+export
+mergeBy_ext : (order : a -> a -> Ordering) -> (left, right : List a) ->
+  Data.List.mergeBy order left right =
+  Data.List.TailRec.mergeBy order left right
+mergeBy_ext order left right = mergeByOnto_ext [] order left right
+
+export
+merge : Ord a => List a -> List a -> List a
+merge = Data.List.TailRec.mergeBy compare
+
+export
+merge_ext : Ord a => (left, right : List a) ->
+  Data.List.merge left right = Data.List.TailRec.merge left right
+merge_ext left right = mergeBy_ext compare left right
+
+
+-- Not quite finished due to a bug. 
+
+sortBy_splitRec : List a -> List a -> (List a -> List a) -> (List a, List a)
+sortBy_splitRec (_::_::xs) (y::ys) zs = sortBy_splitRec xs ys (zs . ((::) y))
+sortBy_splitRec _          ys      zs = (zs [], ys)
+
+sortBy_split : List a -> (List a, List a)
+sortBy_split xs = sortBy_splitRec xs xs id
+
+export
+sortBy : (cmp : a -> a -> Ordering) -> (xs : List a) -> List a
+sortBy cmp []  = []
+sortBy cmp [x] = [x]
+sortBy cmp xs = let (x, y) = sortBy_split xs in
+    Data.List.TailRec.mergeBy cmp
+          (Data.List.TailRec.sortBy cmp (assert_smaller xs x))
+          (Data.List.TailRec.sortBy cmp (assert_smaller xs y))
+
+
+{-- -- This code seems to make Idris2 loop
+export
+sortBy_ext : (cmp : a -> a -> Ordering) -> (xs : List a) -> 
+  Data.List.sortBy cmp xs = Data.List.TailRec.sortBy cmp xs
+sortBy_ext cmp []  = Refl
+sortBy_ext cmp [x] = Refl
+sortBy_ext cmp xs@(y::ys) = let (x, y) = split xs in
+  Calculate [
+  Data.List.mergeBy cmp
+    (Data.List.sortBy cmp (assert_smaller xs x))
+    (Data.List.sortBy cmp (assert_smaller xs y))
+  ==| ?help1 ,
+  Data.List.TailRec.mergeBy cmp
+    (Data.List.TailRec.sortBy cmp (assert_smaller xs x))
+    (Data.List.TailRec.sortBy cmp (assert_smaller xs y))
+  ==| QED
+  ]
+--}

--- a/libs/base/Syntax/PreorderReasoning.idr
+++ b/libs/base/Syntax/PreorderReasoning.idr
@@ -1,0 +1,42 @@
+|||  Until Idris2 starts supporting the 'syntax' keyword, here's a
+|||  poor-man's equational reasoning
+module Syntax.PreorderReasoning
+
+||| Deep embedding of equation derivation sequences.
+||| Using the Nil, (::) constructors lets us use list syntax.
+public export
+data Derivation : (x : a) -> (y : b) -> Type where
+  Nil : Derivation x x
+  (::) : (x = y) -> Derivation y z -> Derivation x z
+  
+infix 1 ==|
+
+||| Explicate the term under consideration and the justification for
+||| the next step.
+export
+(==|) : (x : a) -> (x = y) -> x = y
+(==|) x pf = pf
+
+||| Finishg the derivation.
+||| A bit klunky, but this /is/ a poor-man's version.
+export
+QED : {x : a} -> x = x
+QED = Refl
+
+export
+Calculate : Derivation x y -> x = y
+Calculate [] = Refl
+Calculate (Refl :: der) = Calculate der
+
+{--
+||| Requires Data.Nata
+example : (x : Nat) -> (x + 1) + 0 = 1 + x
+example x = Calculate [
+  (x + 1) + 0 
+  ==| plusZeroRightNeutral (x + 1) ,
+  x + 1
+  ==| plusCommutative x 1 ,
+  1 + x  
+  ==| QED
+  ]
+--}

--- a/libs/base/Syntax/WithProof.idr
+++ b/libs/base/Syntax/WithProof.idr
@@ -1,0 +1,8 @@
+module Syntax.WithProof
+
+||| Until Idris2 supports the 'with (...) proof p' construct, here's a
+||| poor-man's replacement.
+prefix 10 @@
+public export
+(@@) : (t : a ) -> (u : a ** t = u)
+(@@) x = ( x ** Refl)


### PR DESCRIPTION
I've made tail-recursive versions of the `Data.List` functions, as Idris has been stack-overflowing on Frex with lots of stack frames from `List.length`.

Since we might want to also reason about the tail-recursive versions inductively, I've also included proofs they are all extensionally equivalent to their non-tail recursive counterparts.

I mostly just bashed this out, so lots of rooms to refactor it, and if there's something specific that bothers you, just tell me and I'll change it.