### PR TITLE
Port Debug.Trace from Idris 1

### DIFF
--- a/libs/base/Debug/Trace.idr
+++ b/libs/base/Debug/Trace.idr
@@ -1,0 +1,8 @@
+module Debug.Trace
+
+import Prelude
+import PrimIO
+
+export
+trace : (msg : String) -> (result : a) -> a
+trace x val = unsafePerformIO (do putStrLn x; pure val)

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -22,6 +22,8 @@ modules = Control.Monad.Identity,
           Data.Strings,
           Data.Vect,
 
+          Debug.Trace,
+
           Decidable.Equality,
 
           Language.Reflection,


### PR DESCRIPTION
`trace` is quite useful when debugging, so I've copied the definition from the Idris 1 base package sources. I've locally rebuilt and reinstalled the Idris 2 compiler, and it compiles and runs the following program with the expected results:

```idris
module Main

import Debug.Trace

main : IO ()
main = do putStr "the sum of 2 and 3 is: "
          let sum = trace "boo!" (2 + 3)
          putStrLn (show sum)
```

```shell-session
$ idris2 -x main test.idr
the sum of 2 and 3 is: boo!
5
```

`trace` might alternatively be implementable using linear types, but I don't know enough about how that works to know if it's possible.