### PR TITLE
allow overriding racket/chicken paths through environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq ($(shell git status >/dev/null 2>&1; echo $$?), 0)
     endif
 endif
 
-IDRIS2_VERSION=${MAJOR}.${MINOR}.${PATCH}${VER_TAG}
+IDRIS2_VERSION:=${MAJOR}.${MINOR}.${PATCH}${VER_TAG}
 
 PREFIX ?= ${HOME}/.idris2
 export IDRIS2_PATH = ${CURDIR}/libs/prelude/build/ttc:${CURDIR}/libs/base/build/ttc

--- a/src/Compiler/Scheme/Chicken.idr
+++ b/src/Compiler/Scheme/Chicken.idr
@@ -21,10 +21,14 @@ import System.Info
 %default covering
 
 findCSI : IO String
-findCSI = pure "/usr/bin/env csi"
+findCSI =
+  do env <- getEnv "CHICKEN_CSI"
+     pure $ fromMaybe "/usr/bin/env -S csi" env
 
 findCSC : IO String
-findCSC = pure "/usr/bin/env csc"
+findCSC =
+  do env <- getEnv "CHICKEN_CSC"
+     pure $ fromMaybe "/usr/bin/env -S csc" env
 
 schHeader : List String -> String
 schHeader ds

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -20,10 +20,14 @@ import System.Info
 %default covering
 
 findRacket : IO String
-findRacket = pure "/usr/bin/env racket"
+findRacket =
+  do env <- getEnv "RACKET"
+     pure $ fromMaybe "/usr/bin/env -S racket" env
 
 findRacoExe : IO String
-findRacoExe = pure "raco exe"
+findRacoExe =
+  do env <- getEnv "RACKET_RACO"
+     pure $ (fromMaybe "/usr/bin/env -S raco" env) ++ " exe"
 
 schHeader : String -> String
 schHeader libs

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -82,25 +82,31 @@ fail err
 runTest : String -> String -> IO Bool
 runTest prog testPath
     = do chdir testPath
-         putStr $ testPath ++ ": "
-         system $ "sh ./run " ++ prog ++ " | tr -d '\\r' > output"
-         Right out <- readFile "output"
-               | Left err => do print err
-                                pure False
-         Right exp <- readFile "expected"
-               | Left err => do print err
-                                pure False
-
-         if (out == exp)
-            then putStrLn "success"
-            else do
-              putStrLn "FAILURE"
-              putStrLn "Expected:"
-              printLn exp
-              putStrLn "Given:"
-              printLn out
+         isSuccess <- runTest'
          chdir "../.."
-         pure (out == exp)
+         pure isSuccess
+    where
+        runTest' : IO Bool
+        runTest'
+            = do putStr $ testPath ++ ": "
+                 system $ "sh ./run " ++ prog ++ " | tr -d '\\r' > output"
+                 Right out <- readFile "output"
+                     | Left err => do print err
+                                      pure False
+                 Right exp <- readFile "expected"
+                     | Left err => do print err
+                                      pure False
+
+                 if (out == exp)
+                    then putStrLn "success"
+                    else do
+                      putStrLn "FAILURE"
+                      putStrLn "Expected:"
+                      printLn exp
+                      putStrLn "Given:"
+                      printLn out
+
+                 pure (out == exp)
 
 exists : String -> IO Bool
 exists f


### PR DESCRIPTION
This is to help Idris2 generate correct scheme output on NixOS where
Racket and Chicken aren't installed in the standard locations, and
the /usr/bin/env trampoline is disabled at package build time.
The Chez backend already supports overrides.

Also, fixed the test runner to restore the correct working directory
after a failed test, and fixed the top-level Makefile to allow the
IDRIS2_VERSION variable to be queried without building the project.