### PR TITLE
Reorder Scheme compilers order to pick generic Scheme last.

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -25,7 +25,7 @@ findChez
          case env of
             Just n => pure n
             Nothing => do e <- firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
-                                    x <- ["scheme", "chez", "chezscheme9.5"]]
+                                    x <- ["chez", "chezscheme9.5", "scheme"]]
                           pure $ fromMaybe "/usr/bin/env -S scheme" e
 
 locate : {auto c : Ref Ctxt Defs} ->

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -125,7 +125,7 @@ findChez
          case env of
             Just n => pure $ Just n
             Nothing => firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
-                                    x <- ["scheme", "chez", "chezscheme9.5"]]
+                                    x <- ["chez", "chezscheme9.5", "scheme"]]
 
 runChezTests : String -> List String -> IO (List Bool)
 runChezTests prog tests


### PR DESCRIPTION
This fixes the issue where some Scheme compiler like mit-scheme is
installed and that gets picked up first, leading to an infinite
loop in the tests.

Also see attached image in the P.R:

On a system with `mit-scheme` as the default Scheme compiler, the following step hangs forever as part of `make install`:

![Screenshot 2019-12-21 at 6 13 40 PM](https://user-images.githubusercontent.com/2051158/71308428-5ca49780-2422-11ea-8a77-053e8cf58cd1.png)

My  understanding is that the `mit-scheme` instance simple starts a REPL that will wait around forever for input that is never received.

