### PR TITLE
Irrelevance stdlib

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -808,9 +808,9 @@ implementation {n : Nat} -> Traversable (Vect n) where
 
 ||| A proof that some element is found in a vector
 public export
-data Elem : a -> Vect k a -> Type where
-     Here : Elem x (x::xs)
-     There : (later : Elem x xs) -> Elem x (y::xs)
+data Elem : (0 x : a) -> (0 xs : Vect k a) -> Type where
+     Here : {0 x : a} -> Elem x (x::xs)
+     There : {0 x : a} -> (later : Elem x xs) -> Elem x (y::xs)
 
 ||| Nothing can be in an empty Vect
 export

--- a/libs/prelude/Builtin.idr
+++ b/libs/prelude/Builtin.idr
@@ -48,7 +48,7 @@ data Void : Type where
 -- Equality
 
 public export
-data Equal : forall a, b . a -> b -> Type where
+data Equal : forall a, b . (0 x : a)  -> (0 y : b) -> Type where
      Refl : {0 x : a} -> Equal x x
 
 %name Equal prf
@@ -59,11 +59,11 @@ infix 9 ===, ~=~
 -- equality has the same type, but there's not other evidence available
 -- to help with unification
 public export
-(===) : (x : a) -> (y : a) -> Type
+(===) : (0 x : a) -> (0 y : a) -> Type
 (===) = Equal
 
 public export
-(~=~) : (x : a) -> (y : b) -> Type
+(~=~) : (0 x : a) -> (0 y : b) -> Type
 (~=~) = Equal
 
 

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1189,7 +1189,7 @@ record SearchData where
         * If none succeed, move on to the next group
 
        This allows us to prioritise some names (e.g. to declare 'open' hints,
-       which we might us to open an implementation working as a module, or to
+       which we might use to open an implementation working as a module, or to
        declare a named implementation to be used globally), and to have names
        which are only used if all else fails (e.g. as a defaulting mechanism),
        while the proof search mechanism doesn't need to know about any of the


### PR DESCRIPTION
Add missing irrelevance annotations to standard library ( 43ed2f9 )

Data.Vect.Elem
Hetrogeneous and Homogeneous equality

Also (minor): fix typo in a comment ( e6debc9 )

(seemed silly to put this in a separate pull request)

