### PR TITLE
Fix IDE Mode for Atom

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -179,7 +179,9 @@ idePutStrLn outf i msg
 
 printIDEWithStatus : File -> Integer -> String -> SExp -> Core ()
 printIDEWithStatus outf i status msg
-    = do let m = SExpList [SymbolAtom status, toSExp msg ]
+    = do let m = SExpList [SymbolAtom status, toSExp msg,
+                           -- highlighting; currently blank
+                           SExpList []]
          send outf (SExpList [SymbolAtom "return", m, toSExp i])
 
 printIDEResult : File -> Integer -> SExp -> Core ()

--- a/src/Idris/REPLCommon.idr
+++ b/src/Idris/REPLCommon.idr
@@ -33,7 +33,9 @@ printWithStatus status msg
          case idemode opts of
               REPL _ => coreLift $ putStrLn msg
               IDEMode i _ f =>
-                do let m = SExpList [SymbolAtom status, toSExp msg ]
+                do let m = SExpList [SymbolAtom status, toSExp msg,
+                                     -- highlighting; currently blank
+                                     SExpList []]
                    send f (SExpList [SymbolAtom "return", m, toSExp i])
 
 export

--- a/tests/ideMode/ideMode001/expected
+++ b/tests/ideMode/ideMode001/expected
@@ -1,4 +1,4 @@
 000018(:protocol-version 2 0)
 000038(:write-string "1/1: Building LocType (LocType.idr)" 1)
-000015(:return (:ok ()) 1)
+000018(:return (:ok () ()) 1)
 Alas the file is done, aborting

--- a/tests/ideMode/ideMode002/gen_expected.sh
+++ b/tests/ideMode/ideMode002/gen_expected.sh
@@ -9,7 +9,7 @@ MAJOR=`echo $VERSION | cut -d. -f1`
 MINOR=`echo $VERSION | cut -d. -f2`
 PATCH=`echo $VERSION | cut -d. -f3`
 
-EXPECTED_LINE="(:return (:ok ((${MAJOR} ${MINOR} ${PATCH}) (\"${TAG}\"))) 1)"
+EXPECTED_LINE="(:return (:ok ((${MAJOR} ${MINOR} ${PATCH}) (\"${TAG}\")) ()) 1)"
 EXPECTED_LENGTH=$(expr ${#EXPECTED_LINE} + 1) # +LF
 
 sed -e "s/__EXPECTED_LINE__/$(printf '%06x' ${EXPECTED_LENGTH})${EXPECTED_LINE}/g" expected.in > expected


### PR DESCRIPTION
Unfortunately a change in 432cc7c breaks the `type-of` (and maybe other commands) in the Atom IDE plugin. By looking at the output of the IDE Mode before this change I could see that there was a missing argument in the return value (See example at the bottom). The extra argument is used for highlighting, though it is currently not in use, as noted by the previous implementation of `printWithStatus`:
https://github.com/edwinb/Idris2/blob/a145ba99d7bda290c1b0ba189849d5b764795bba/src/Idris/REPLCommon.idr#L36-L39

@abailly Were there any specific reasons for removing this extra argument in the IDE Mode?

I am sorry if this pull request breaks any other IDE integrations (though the format should now be more similar to Idris 1's format).

---

IDE Mode before 432cc7c (Note the extra `()` argument.):
```
000015((:type-of "foo") 1)
000049(:return (:ok "-------------------------------------
foo : IO ()" ()) 1)
```

IDE Mode after 432cc7c:
```
000015((:type-of "foo") 1)
000046(:return (:ok "-------------------------------------
foo : IO ()") 1)
```

EDIT: Forgot to fix the tests. Fixed now.