### PR TITLE
WIP - Remove redundant linear check on LHS

### DIFF
--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -442,36 +442,11 @@ checkBindVar rig elabinfo nest env fc str topexp
                    addNameType fc (UN str) env exp
                    checkExp rig elabinfo env fc tm (gnf env exp) topexp
               Just bty =>
-                do -- Check rig is consistent with the one in bty, and
-                   -- update if necessary
-                   combine (UN str) rig (bindingRig bty)
-                   let tm = bindingTerm bty
+                do let tm = bindingTerm bty
                    let ty = bindingType bty
                    defs <- get Ctxt
                    addNameType fc (UN str) env ty
                    checkExp rig elabinfo env fc tm (gnf env ty) topexp
-  where
-    updateRig : Name -> RigCount -> List (Name, ImplBinding vars) ->
-                List (Name, ImplBinding vars)
-    updateRig n c [] = []
-    updateRig n c ((bn, r) :: bs)
-        = if n == bn
-             then case r of
-                  NameBinding _ p tm ty => (bn, NameBinding c p tm ty) :: bs
-                  AsBinding _ p tm ty pat => (bn, AsBinding c p tm ty pat) :: bs
-             else (bn, r) :: updateRig n c bs
-
-    combine : Name -> RigCount -> RigCount -> Core ()
-    combine n Rig1 Rig1 = throw (LinearUsed fc 2 n)
-    combine n Rig1 RigW = throw (LinearUsed fc 2 n)
-    combine n RigW Rig1 = throw (LinearUsed fc 2 n)
-    combine n RigW RigW = pure ()
-    combine n Rig0 c = pure ()
-    combine n c Rig0
-       -- It was 0, make it c
-       = do est <- get EST
-            put EST (record { boundNames $= updateRig n c,
-                              toBind $= updateRig n c } est)
 
 export
 checkBindHere : {vars : _} ->

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -352,7 +352,9 @@ checkClause mult hashit n opts nest env (ImpossibleClause fc lhs)
                             else throw (ValidCase fc env (Right err)))
 checkClause {vars} mult hashit n opts nest env (PatClause fc lhs_in rhs)
     = do (_, (vars'  ** (sub', env', nest', lhstm', lhsty'))) <-
-             checkLHS mult hashit n opts nest env fc lhs_in
+             wrapError
+                   (Core.InLHS fc !(getFullName (Resolved n)))
+                   (checkLHS mult hashit n opts nest env fc lhs_in)
          let rhsMode = case mult of
                             Rig0 => InType
                             _ => InExpr

--- a/tests/ttimp/qtt003/expected
+++ b/tests/ttimp/qtt003/expected
@@ -1,4 +1,4 @@
 Processing as TTImp
 QTTEq.yaff:8:1--9:1:When elaborating left hand side of Main.okay:
-QTTEq.yaff:8:9--8:12:There are 2 uses of linear name x
+QTTEq.yaff:8:1--9:1:There are 2 uses of linear name x
 Yaffle> Yaffle> Yaffle> Yaffle> Yaffle> Bye for now!


### PR DESCRIPTION
The same `combine` logic was used in `Elab/ImplicitBind.idr` and `TTImp/ProcessDef.idr` but turned out the check was redundant.

However, while the test suite catches the change, the error report is different because the position of the terms on the LHS isn't accessible at the `ProcessDef` phase.

Should I change the test suite (like I did in this PR) to reflect the change or is the error reporting necessary to keep?
