### PR TITLE
minor: simplify mutual recursion block

### DIFF
--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -35,10 +35,10 @@ Weaken NestedNames where
 -- Higher level expressions (e.g. case, pattern matching let, where blocks,
 -- do notation, etc, should elaborate via this, perhaps in some local
 -- context).
-mutual
-  public export
-  data BindMode = PI RigCount | PATTERN | NONE
+public export
+data BindMode = PI RigCount | PATTERN | NONE
 
+mutual
   public export
   data RawImp : Type where
        IVar : FC -> Name -> RawImp


### PR DESCRIPTION
Move `BindMode` datatype outside the `mutual` block as mutual
recursion isn't necessary to define it.