### PR TITLE
Bring `src/Text/Parser` and its dependencies closer to idris2

### DIFF
--- a/src/Control/Delayed.idr
+++ b/src/Control/Delayed.idr
@@ -21,6 +21,7 @@ lazy = delayed LazyValue
 
 ||| Conditionally delay a value.
 export
-delay : (d : Bool) -> a -> delayed r d a
+delay : {r : DelayReason} -> (d : Bool) -> a -> delayed r d a
 delay False x = x
-delay True x = Delay x
+delay {r=Infinite}  True x = Delay x
+delay {r=LazyValue} True x = Delay x

--- a/src/Data/Bool/Extra.idr
+++ b/src/Data/Bool/Extra.idr
@@ -1,32 +1,38 @@
 module Data.Bool.Extra
 
-%access public export
 %default total
 
+public export
 andSameNeutral : (x : Bool) -> x && x = x
 andSameNeutral False = Refl
 andSameNeutral True = Refl
 
+public export
 andFalseFalse : (x : Bool) -> x && False = False
 andFalseFalse False = Refl
 andFalseFalse True = Refl
 
+public export
 andTrueNeutral : (x : Bool) -> x && True = x
 andTrueNeutral False = Refl
 andTrueNeutral True = Refl
 
+public export
 orSameNeutral : (x : Bool) -> x || x = x
 orSameNeutral False = Refl
 orSameNeutral True = Refl
 
+public export
 orFalseNeutral : (x : Bool) -> x || False = x
 orFalseNeutral False = Refl
 orFalseNeutral True = Refl
 
+public export
 orTrueTrue : (x : Bool) -> x || True = True
 orTrueTrue False = Refl
 orTrueTrue True = Refl
 
+public export
 orSameAndRightNeutral : (x, right : Bool) -> x || (x && right) = x
 orSameAndRightNeutral False _ = Refl
 orSameAndRightNeutral True _ = Refl

--- a/src/Text/Parser/Core.idr
+++ b/src/Text/Parser/Core.idr
@@ -43,7 +43,7 @@ export %inline
         Grammar tok c1 a ->
         inf c1 (a -> Grammar tok c2 b) ->
         Grammar tok (c1 || c2) b
-(>>=) {c1 = False} = SeqEmpty {c2=c2}
+(>>=) {c1 = False} = SeqEmpty
 (>>=) {c1 = True}  = SeqEat
 
 ||| Sequence two grammars. If either consumes some input, the sequence is
@@ -75,7 +75,7 @@ export
 
 ||| Allows the result of a grammar to be mapped to a different value.
 export
-{c : Bool} -> Functor (Grammar tok c) where
+Functor (Grammar tok c) where
   map f (Empty val)  = Empty (f val)
   map f (Fail fatal msg) = Fail fatal msg
   map f (MustWork g) = MustWork (map f g)

--- a/src/Text/Quantity.idr
+++ b/src/Text/Quantity.idr
@@ -1,13 +1,14 @@
 module Text.Quantity
 
-%access public export
 %default total
 
+public export
 record Quantity where
   constructor Qty
   min : Nat
   max : Maybe Nat
 
+public export
 Show Quantity where
   show (Qty Z Nothing) = "*"
   show (Qty Z (Just (S Z))) = "?"
@@ -21,18 +22,23 @@ Show Quantity where
                                      then ""
                                      else "," ++ show max'
 
+public export
 between : Nat -> Nat -> Quantity
 between min max = Qty min (Just max)
 
+public export
 atLeast : Nat -> Quantity
 atLeast min = Qty min Nothing
 
+public export
 atMost : Nat -> Quantity
 atMost max = Qty 0 (Just max)
 
+public export
 exactly : Nat -> Quantity
 exactly n = Qty n (Just n)
 
+public export
 inOrder : Quantity -> Bool
 inOrder (Qty min Nothing) = True
 inOrder (Qty min (Just max)) = min <= max

--- a/src/Text/Token.idr
+++ b/src/Text/Token.idr
@@ -1,6 +1,5 @@
 module Text.Token
 
-%access public export
 %default total
 
 ||| For a type `kind`, specify a way of converting the recognised
@@ -18,6 +17,7 @@ module Text.Token
 |||   tokValue SKInt x = cast x
 |||   tokValue SKComma x = ()
 ||| ```
+public export
 interface TokenKind (k : Type) where
   ||| The type that a token of this kind converts to.
   TokType : k -> Type
@@ -27,6 +27,7 @@ interface TokenKind (k : Type) where
   tokValue : (kind : k) -> String -> TokType kind
 
 ||| A token of a particular kind and the text that was recognised.
+public export
 record Token k where
   constructor Tok
   kind : k
@@ -34,5 +35,6 @@ record Token k where
 
 ||| Get the value of a `Token k`. The resulting type depends upon
 ||| the kind of token.
+public export
 value : TokenKind k => (t : Token k) -> TokType (kind t)
 value (Tok k x) = tokValue k x


### PR DESCRIPTION
* Removing `%access` directives and inlining their visibility modifiers
* Fixing irrelevance annotations
* Including some standard libraries

The result is still not idris2 ready:

1. Incompatibility with the new Laziness mechanism, as it's missing
   some previous laziness/codata bindings

2. Some standard library functions moved around, and are now found in
   `Data.Nat`, that doesn't exist in Idris1

3. Annotating the `Functor (Grammar ... c ...)` implementation with a 
   relevance annotation for `c`, which seems to be incompatible with Idris1