### PR TITLE
Add PATH lookup to find Chez Scheme

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -19,14 +19,20 @@ import System.Info
 
 %default covering
 
+
+pathLookup : IO String
+pathLookup
+    = do path <- getEnv "PATH"
+         let pathList = split (== ':') $ fromMaybe "/usr/bin:/usr/local/bin" path
+         let candidates = [p ++ "/" ++ x | p <- pathList,
+                                           x <- ["chez", "chezscheme9.5", "scheme"]]
+         e <- firstExists candidates
+         pure $ fromMaybe "/usr/bin/env scheme" e
+
 findChez : IO String
 findChez
-    = do env <- getEnv "CHEZ"
-         case env of
-            Just n => pure n
-            Nothing => do e <- firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
-                                    x <- ["chez", "chezscheme9.5", "scheme"]]
-                          pure $ fromMaybe "/usr/bin/env scheme" e
+    = do Just chez <- getEnv "CHEZ" | Nothing => pathLookup
+         pure chez
 
 -- Given the chez compiler directives, return a list of pairs of:
 --   - the library file name

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -144,13 +144,18 @@ firstExists : List String -> IO (Maybe String)
 firstExists [] = pure Nothing
 firstExists (x :: xs) = if !(exists x) then pure (Just x) else firstExists xs
 
+pathLookup : IO (Maybe String)
+pathLookup = do
+  path <- getEnv "PATH"
+  let pathList = split (== ':') $ fromMaybe "/usr/bin:/usr/local/bin" path
+  let candidates = [p ++ "/" ++ x | p <- pathList,
+                                    x <- ["chez", "chezscheme9.5", "scheme"]]
+  firstExists candidates
+
 findChez : IO (Maybe String)
 findChez
-    = do env <- getEnv "CHEZ"
-         case env of
-            Just n => pure $ Just n
-            Nothing => firstExists [p ++ x | p <- ["/usr/bin/", "/usr/local/bin/"],
-                                    x <- ["chez", "chezscheme9.5", "scheme"]]
+    = do Just chez <- getEnv "CHEZ" | Nothing => pathLookup
+         pure $ Just chez
 
 runChezTests : String -> List String -> IO (List Bool)
 runChezTests prog tests


### PR DESCRIPTION
On some systems "/usr/bin" and "/usr/local/bin" are not used.
If CHEZ env variable is not defined, lookup for chez in the PATH if
defined. Otherwise falls back to the old behaviour. (ie. lookup in
"/usr/bin" and "/usr/local/bin" as a last resort)