### PR TITLE
Only ignore the executables in the root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 
 *.dSYM
 
-idris2
-runtests
+/idris2
+/runtests
 
 dist/idris2.c
 


### PR DESCRIPTION
The previous rule accidentally ignored all files in `tests/idris2`.

I found which rule that ignored the files in `tests/idris2` by using the command `git check-ignore -v <ignored-file>`.