### PR TITLE
Use Makefile for tests/chez/chez013

### DIFF
--- a/tests/chez/chez013/.gitignore
+++ b/tests/chez/chez013/.gitignore
@@ -1,0 +1,7 @@
+*.d
+*.o
+*.obj
+*.so
+*.dylib
+*.dll
+

--- a/tests/chez/chez013/Makefile
+++ b/tests/chez/chez013/Makefile
@@ -1,0 +1,51 @@
+
+TARGET = libstruct
+
+MACHINE := $(shell $(CC) -dumpmachine)
+ifneq (,$(findstring cygwin, $(MACHINE)))
+	OS := windows
+	SHLIB_SUFFIX := .dll
+else ifneq (,$(findstring mingw, $(MACHINE)))
+	OS := windows
+	SHLIB_SUFFIX := .dll
+else ifneq (,$(findstring windows, $(MACHINE)))
+	OS := windows
+	SHLIB_SUFFIX := .dll
+else ifneq (,$(findstring darwin, $(MACHINE)))
+	OS := darwin
+	SHLIB_SUFFIX := .dylib
+	CFLAGS += -fPIC
+else
+	OS := unix
+	SHLIB_SUFFIX := .so
+	CFLAGS += -fPIC
+endif
+
+
+CFLAGS := -Wall -Wextra $(CFLAGS)
+LDFLAGS := $(LDFLAGS)
+
+SRCS = $(wildcard *.c)
+OBJS = $(SRCS:.c=.o)
+DEPS = $(OBJS:.o=.d)
+
+
+all: ${TARGET}$(SHLIB_SUFFIX)
+
+$(TARGET)$(SHLIB_SUFFIX): $(OBJS)
+	$(CC) -shared ${LDFLAGS} -o $@ $^
+
+
+-include $(DEPS)
+
+%.d: %.c
+	@$(CPP) $(CFLAGS) $< -MM -MT $(@:.d=.o) >$@
+
+
+.PHONY: clean
+
+clean :
+	rm -f $(OBJS) $(TARGET)$(SHLIB_SUFFIX)
+
+cleandep: clean
+	rm -f ${DEPS}

--- a/tests/chez/chez013/run
+++ b/tests/chez/chez013/run
@@ -1,3 +1,4 @@
-cc --shared struct.c -fPIC -o libstruct.so
+make all > /dev/null
 $1 --no-banner Struct.idr < input
-rm -rf build libstruct.* 
+rm -rf build
+make clean > /dev/null


### PR DESCRIPTION
Fixes running tests on MacOS where dlopen(3) loads shared libraries with 'dylib' extension.