### PR TITLE
Remove rig count

### DIFF
--- a/src/Algebra.idr
+++ b/src/Algebra.idr
@@ -1,0 +1,9 @@
+module Algebra
+
+import public Algebra.ZeroOneOmega
+import public Algebra.Semiring
+import public Algebra.Preorder
+
+public export
+RigCount : Type
+RigCount = ZeroOneOmega

--- a/src/Algebra/Preorder.idr
+++ b/src/Algebra/Preorder.idr
@@ -1,0 +1,29 @@
+module Algebra.Preorder
+
+||| Preorder defines a binary relation using the `<=` operator
+public export
+interface Preorder a where
+  (<=) : a -> a -> Bool
+  preorderRefl : {x : a} -> x <= x = True
+  preorderTrans : {x, y, z : a} -> x <= y = True -> y <= z = True -> x <= z = True
+
+||| Least Upper Bound, replace max using only Preorder
+export
+lub : Preorder a => a -> a -> a
+lub x y = if x <= y then y else x
+
+||| Greatest Lower Bound, replaces min using only Preorder
+export
+glb : Preorder a => a -> a -> a
+glb x y = if x <= y then x else y
+
+||| Strict less-than using the relation from a preorder
+public export
+(<) : (Preorder a, Eq a) => a -> a -> Bool
+(<) x y = x <= y && x /= y
+
+||| The greatest bound of a bounded lattice, we only need to know about preorders however
+public export
+interface Preorder a => Top a where
+  top : a
+  topAbs : {x : a} -> x <= top = True

--- a/src/Algebra/Semiring.idr
+++ b/src/Algebra/Semiring.idr
@@ -1,0 +1,58 @@
+module Algebra.Semiring
+
+%default total
+
+infixl 8 |+|
+infixl 9 |*|
+
+||| A Semiring has two binary operations and an identity for each
+public export
+interface Semiring a where
+  (|+|) : a -> a -> a
+  plusNeutral : a
+  (|*|) : a -> a -> a
+  timesNeutral : a
+
+||| Erased linearity corresponds to the neutral for |+|
+public export
+erased : Semiring a => a
+erased = plusNeutral
+
+||| Purely linear corresponds to the neutral for |*|
+public export
+linear : Semiring a => a
+linear = timesNeutral
+
+||| A semiring eliminator
+public export
+elimSemi : (Semiring a, Eq a) => (zero : b) -> (one : b) -> (a -> b) -> a -> b
+elimSemi zero one other r {a} =
+  if r == Semiring.plusNeutral {a}
+     then zero
+     else if r == Semiring.timesNeutral {a}
+             then one
+             else other r
+
+export
+isErased : (Semiring a, Eq a) => a -> Bool
+isErased = elimSemi True False (const False)
+
+export
+isLinear : (Semiring a, Eq a) => a -> Bool
+isLinear = elimSemi False True (const False)
+
+export
+isRigOther : (Semiring a, Eq a) => a -> Bool
+isRigOther = elimSemi False False (const True)
+
+export
+branchZero : (Semiring a, Eq a) => Lazy b -> Lazy b -> a -> b
+branchZero yes no rig = if isErased rig then yes else no
+
+export
+branchOne : (Semiring a, Eq a) => Lazy b -> Lazy b -> a -> b
+branchOne yes no rig = if isLinear rig then yes else no
+
+export
+branchVal : (Semiring a, Eq a) => Lazy b -> Lazy b -> a -> b
+branchVal yes no rig = if isRigOther rig then yes else no

--- a/src/Algebra/ZeroOneOmega.idr
+++ b/src/Algebra/ZeroOneOmega.idr
@@ -1,0 +1,70 @@
+module Algebra.ZeroOneOmega
+
+import Algebra.Semiring
+import Algebra.Preorder
+
+export
+data ZeroOneOmega = Rig0 | Rig1 | RigW
+
+Preorder ZeroOneOmega where
+  Rig0 <= _ = True
+  Rig1 <= Rig1 = True
+  Rig1 <= RigW = True
+  RigW <= RigW = True
+  _ <= _ = False
+  preorderRefl {x = Rig0} = Refl
+  preorderRefl {x = Rig1} = Refl
+  preorderRefl {x = RigW} = Refl
+  preorderTrans {x = Rig0} {y = y} {z = z} a b = Refl
+  preorderTrans {x = Rig1} {y = Rig0} {z = Rig0} Refl Refl impossible
+  preorderTrans {x = Rig1} {y = Rig1} {z = Rig0} _ Refl impossible
+  preorderTrans {x = Rig1} {y = RigW} {z = Rig0} _ Refl impossible
+  preorderTrans {x = Rig1} {y = y} {z = Rig1} a b = Refl
+  preorderTrans {x = Rig1} {y = y} {z = RigW} a b = Refl
+  preorderTrans {x = RigW} {y = Rig0} {z = _} Refl _ impossible
+  preorderTrans {x = RigW} {y = Rig1} {z = _} Refl _ impossible
+  preorderTrans {x = RigW} {y = RigW} {z = z} a b = b
+
+public export
+Eq ZeroOneOmega where
+  (==) Rig0 Rig0 = True
+  (==) Rig1 Rig1 = True
+  (==) RigW RigW = True
+  (==) _ _ = False
+
+export
+Show ZeroOneOmega where
+  show Rig0 = "Rig0"
+  show Rig1 = "Rig1"
+  show RigW = "RigW"
+
+export
+rigPlus : ZeroOneOmega -> ZeroOneOmega -> ZeroOneOmega
+rigPlus Rig0 a = a
+rigPlus a Rig0 = a
+rigPlus Rig1 a = RigW
+rigPlus a Rig1 = RigW
+rigPlus RigW RigW = RigW
+
+export
+rigMult : ZeroOneOmega -> ZeroOneOmega -> ZeroOneOmega
+rigMult Rig0 _ = Rig0
+rigMult _ Rig0 = Rig0
+rigMult Rig1 a = a
+rigMult a Rig1 = a
+rigMult RigW RigW = RigW
+
+public export
+Semiring ZeroOneOmega where
+  (|+|) = rigPlus
+  (|*|) = rigMult
+  plusNeutral = Rig0
+  timesNeutral = Rig1
+
+||| The top value of a lattice
+export
+Top ZeroOneOmega where
+  top = RigW
+  topAbs {x = Rig0} = Refl
+  topAbs {x = Rig1} = Refl
+  topAbs {x = RigW} = Refl

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -213,10 +213,10 @@ mutual
       = pure $ CApp fc (CRef fc mn) !(traverse (toCExp tags n) args)
   toCExpTm tags n (Bind fc x (Lam _ _ _) sc)
       = pure $ CLam fc x !(toCExp tags n sc)
-  toCExpTm tags n (Bind fc x (Let Rig0 val _) sc)
-      = pure $ shrinkCExp (DropCons SubRefl) !(toCExp tags n sc)
-  toCExpTm tags n (Bind fc x (Let _ val _) sc)
-      = pure $ CLet fc x True !(toCExp tags n val) !(toCExp tags n sc)
+  toCExpTm tags n (Bind fc x (Let rig val _) sc)
+      = pure $ branchZero (shrinkCExp (DropCons SubRefl) !(toCExp tags n sc))
+                          (CLet fc x True !(toCExp tags n val) !(toCExp tags n sc))
+                          rig
   toCExpTm tags n (Bind fc x (Pi c e ty) sc)
       = pure $ CCon fc (UN "->") 1 [!(toCExp tags n ty),
                                     CLam fc x !(toCExp tags n sc)]
@@ -436,7 +436,7 @@ nfToCFType : {auto c : Ref Ctxt Defs} ->
              FC -> (inStruct : Bool) -> NF [] -> Core CFType
 nfToCFType _ _ (NPrimVal _ IntType) = pure CFInt
 nfToCFType _ False (NPrimVal _ StringType) = pure CFString
-nfToCFType fc True (NPrimVal _ StringType) 
+nfToCFType fc True (NPrimVal _ StringType)
     = throw (GenericMsg fc "String not allowed in a foreign struct")
 nfToCFType _ _ (NPrimVal _ DoubleType) = pure CFDouble
 nfToCFType _ _ (NPrimVal _ CharType) = pure CFChar
@@ -456,7 +456,7 @@ nfToCFType _ s (NTCon fc n _ _ args)
                 do nargs <- traverse (evalClosure defs) uargs
                    cargs <- traverse (nfToCFType fc s) nargs
                    pure (CFUser n cargs)
-              Struct n fs => 
+              Struct n fs =>
                 do fs' <- traverse
                              (\ (n, ty) =>
                                     do tynf <- evalClosure defs ty

--- a/src/Core/CaseTree.idr
+++ b/src/Core/CaseTree.idr
@@ -222,7 +222,7 @@ mkTerm vars (PTyCon fc x arity xs)
                (map (mkTerm vars) xs)
 mkTerm vars (PConst fc c) = PrimVal fc c
 mkTerm vars (PArrow fc x s t)
-    = Bind fc x (Pi RigW Explicit (mkTerm vars s)) (mkTerm (x :: vars) t)
+    = Bind fc x (Pi top Explicit (mkTerm vars s)) (mkTerm (x :: vars) t)
 mkTerm vars (PDelay fc r ty p)
     = TDelay fc r (mkTerm vars ty) (mkTerm vars p)
 mkTerm vars (PLoc fc n)

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -923,7 +923,7 @@ addBuiltin : {auto x : Ref Ctxt Defs} ->
              Name -> ClosedTerm -> Totality ->
              PrimFn arity -> Core ()
 addBuiltin n ty tot op
-    = do addDef n (MkGlobalDef emptyFC n ty [] [] [] RigW [] Public tot
+    = do addDef n (MkGlobalDef emptyFC n ty [] [] [] top [] Public tot
                                [Inline] Nothing Nothing
                                False False True (Builtin op)
                                Nothing Nothing [])
@@ -1633,7 +1633,7 @@ addData : {auto c : Ref Ctxt Defs} ->
 addData vars vis tidx (MkData (MkCon dfc tyn arity tycon) datacons)
     = do defs <- get Ctxt
          tag <- getNextTypeTag
-         let tydef = newDef dfc tyn RigW vars tycon vis
+         let tydef = newDef dfc tyn top vars tycon vis
                             (TCon tag arity
                                   (paramPos (Resolved tidx) (map type datacons))
                                   (allDet arity)
@@ -1655,7 +1655,7 @@ addData vars vis tidx (MkData (MkCon dfc tyn arity tycon) datacons)
                           Context -> Core Context
     addDataConstructors tag [] gam = pure gam
     addDataConstructors tag (MkCon fc n a ty :: cs) gam
-        = do let condef = newDef fc n RigW vars ty (conVisibility vis) (DCon tag a Nothing)
+        = do let condef = newDef fc n top vars ty (conVisibility vis) (DCon tag a Nothing)
              (idx, gam') <- addCtxt n condef gam
              addDataConstructors (tag + 1) cs gam'
 

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -162,14 +162,16 @@ Show Error where
                    " in " ++ showRel ctx ++ " context"
      where
        showRig : RigCount -> String
-       showRig Rig0 = "irrelevant"
-       showRig Rig1 = "linear"
-       showRig RigW = "unrestricted"
+       showRig = elimSemi
+         "linear"
+         "irrelevant"
+         (const "unrestricted")
 
        showRel : RigCount -> String
-       showRel Rig0 = "irrelevant"
-       showRel Rig1 = "relevant"
-       showRel RigW = "non-linear"
+       showRel = elimSemi
+         "relevant"
+         "irrelevant"
+         (const "non-linear")
   show (BorrowPartial fc env t arg)
       = show fc ++ ":" ++ show t ++ " borrows argument " ++ show arg ++
                    " so must be fully applied"

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -61,7 +61,7 @@ isEmpty defs _ = pure False
 -- Need this to get a NF from a Term; the names are free in any case
 freeEnv : FC -> (vs : List Name) -> Env Term vs
 freeEnv fc [] = []
-freeEnv fc (n :: ns) = PVar RigW Explicit (Erased fc False) :: freeEnv fc ns
+freeEnv fc (n :: ns) = PVar top Explicit (Erased fc False) :: freeEnv fc ns
 
 -- Given a normalised type, get all the possible constructors for that
 -- type family, with their type, name, tag, and arity

--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -67,9 +67,10 @@ Hashable Name where
 
 export
 Hashable RigCount where
-  hashWithSalt h Rig0 = hashWithSalt h 0
-  hashWithSalt h Rig1 = hashWithSalt h 1
-  hashWithSalt h RigW = hashWithSalt h 2
+  hashWithSalt h = elimSemi
+                     (hashWithSalt h 0)
+                     (hashWithSalt h 1)
+                     (const $ hashWithSalt h 2)
 
 export
 Hashable t => Hashable (PiInfo t) where

--- a/src/Core/LinearCheck.idr
+++ b/src/Core/LinearCheck.idr
@@ -73,11 +73,11 @@ mutual
       -- otherwise set it to Rig0
       = if varIdx var == v
            then do scty <- updateHoleType False var zs sc as
-                   let c' = if useInHole then c else Rig0
+                   let c' = if useInHole then c else erased
                    pure (Bind bfc nm (Pi c' e ty) scty)
            else if elem v (map varIdx zs)
                 then do scty <- updateHoleType useInHole var zs sc as
-                        pure (Bind bfc nm (Pi Rig0 e ty) scty)
+                        pure (Bind bfc nm (Pi erased e ty) scty)
                 else do scty <- updateHoleType useInHole var zs sc as
                         pure (Bind bfc nm (Pi c e ty) scty)
   updateHoleType useInHole var zs (Bind bfc nm (Pi c e ty) sc) (a :: as)
@@ -188,16 +188,13 @@ mutual
       getName (x :: xs) (Later p) = getName xs p
 
       rigSafe : RigCount -> RigCount -> Core ()
-      rigSafe Rig1 RigW = throw (LinearMisuse fc name Rig1 RigW)
-      rigSafe Rig0 RigW = throw (LinearMisuse fc name Rig0 RigW)
-      rigSafe Rig0 Rig1 = throw (LinearMisuse fc name Rig0 Rig1)
-      rigSafe _ _ = pure ()
+      rigSafe l r = when (l < r)
+                         (throw (LinearMisuse fc (getName vars prf) l r))
 
       -- count the usage if we're in a linear context. If not, the usage doesn't
       -- matter
       used : RigCount -> Usage vars
-      used Rig1 = [MkVar prf]
-      used _ = []
+      used r = if isLinear r then [MkVar prf] else []
 
   lcheck rig erase env (Ref fc nt fn)
       = do ty <- lcheckDef fc rig erase env fn
@@ -212,10 +209,12 @@ mutual
       = do defs <- get Ctxt
            Just gdef <- lookupCtxtExact (Resolved idx) (gamma defs)
                 | _ => throw (UndefinedName fc n)
-           let expand = case (definition gdef, rig) of
-                             (_, Rig0) => False
-                             (PMDef _ _ _ _ _, _) => True
-                             _ => False
+           let expand = branchZero
+                          False
+                          (case definition gdef of
+                                (PMDef _ _ _ _ _) => True
+                                _ => False)
+                          rig
            logC 10 $ do
              def <- the (Core String) $ case definition gdef of
                          PMDef _ _ (STerm tm) _ _ => do tm' <- toFullNames tm
@@ -234,7 +233,7 @@ mutual
     where
       unusedHoleArgs : List a -> Term vs -> Term vs
       unusedHoleArgs (_ :: args) (Bind bfc n (Pi _ e ty) sc)
-          = Bind bfc n (Pi Rig0 e ty) (unusedHoleArgs args sc)
+          = Bind bfc n (Pi erased e ty) (unusedHoleArgs args sc)
       unusedHoleArgs args (Bind bfc n (Let c e ty) sc)
           = Bind bfc n (Let c e ty) (unusedHoleArgs args sc)
       unusedHoleArgs _ ty = ty
@@ -243,9 +242,11 @@ mutual
       = do (b', bt, usedb) <- lcheckBinder rig erase env b
            -- Anything linear can't be used in the scope of a lambda, if we're
            -- checking in general context
-           let env' = case (rig_in, b) of
-                           (RigW, Lam _ _ _) => eraseLinear env
-                           _ => env
+           let env' = if rig_in == top
+                         then case b of
+                              (Lam _ _ _) => eraseLinear env
+                              _ => env
+                         else env
            (sc', sct, usedsc) <- lcheck rig erase (b' :: env') sc
            defs <- get Ctxt
 
@@ -259,45 +260,40 @@ mutual
 
            -- if there's a hole, assume it will contain the missing usage
            -- if there is none already
-           let used = case rigMult (multiplicity b) rig of
-                           Rig1 => if holeFound && used_in == 0
-                                      then 1
-                                      else used_in
-                           _ => used_in
+           let used = if isLinear ((multiplicity b) |*| rig) &&
+                         holeFound && used_in == 0
+                         then 1
+                         else used_in
 
            when (not erase) $
-               checkUsageOK used (rigMult (multiplicity b) rig)
+               checkUsageOK used ((multiplicity b) |*| rig)
            defs <- get Ctxt
            discharge defs env fc nm b' bt sc' sct (usedb ++ doneScope usedsc)
     where
       rig : RigCount
       rig = case b of
-                 Pi _ _ _ => Rig0
-                 _ => case rig_in of
-                           Rig0 => Rig0
-                           _ => Rig1
+                 Pi _ _ _ => erased
+                 _ => if isErased rig_in
+                         then erased
+                         else linear
 
       getZeroes : Env Term vs -> List (Var vs)
       getZeroes [] = []
       getZeroes (b :: bs)
-          = case multiplicity b of
-                 Rig0 => MkVar First :: map weaken (getZeroes bs)
-                 _ => map weaken (getZeroes bs)
+          = if isErased (multiplicity b)
+               then MkVar First :: map weaken (getZeroes bs)
+               else map weaken (getZeroes bs)
 
       eraseLinear : Env Term vs -> Env Term vs
       eraseLinear [] = []
       eraseLinear (b :: bs)
-          = case multiplicity b of
-                 Rig1 => setMultiplicity b Rig0 :: eraseLinear bs
-                 _ => b :: eraseLinear bs
+          = if isLinear (multiplicity b)
+               then setMultiplicity b erased :: eraseLinear bs
+               else b :: eraseLinear bs
 
       checkUsageOK : Nat -> RigCount -> Core ()
-      checkUsageOK used Rig0 = pure ()
-      checkUsageOK used RigW = pure ()
-      checkUsageOK used Rig1
-          = if used == 1
-               then pure ()
-               else throw (LinearUsed fc used nm)
+      checkUsageOK used r = when (isLinear r && used /= 1)
+                                 (throw (LinearUsed fc used nm))
 
   lcheck rig erase env (App fc f a)
       = do (f', gfty, fused) <- lcheck rig erase env f
@@ -308,10 +304,10 @@ mutual
                      -- if the argument is borrowed, it's okay to use it in
                      -- unrestricted context, because we'll be out of the
                      -- application without spending it
-                   do let checkRig = rigMult rigf rig
+                   do let checkRig = rigf |*| rig
                       (a', gaty, aused) <- lcheck checkRig erase env a
                       sc' <- scdone defs (toClosure defaultOpts env a')
-                      let aerased = if erase && rigf == Rig0 then Erased fc False else a'
+                      let aerased = if erase && isErased rigf then Erased fc False else a'
                       -- Possibly remove this check, or make it a compiler
                       -- flag? It is a useful double check on the result of
                       -- elaboration, but there are pathological cases where
@@ -340,7 +336,7 @@ mutual
       = do (ty', _, u) <- lcheck rig erase env ty
            pure (TDelayed fc r ty', gType fc, u)
   lcheck rig erase env (TDelay fc r ty val)
-      = do (ty', _, _) <- lcheck Rig0 erase env ty
+      = do (ty', _, _) <- lcheck erased erase env ty
            (val', gty, u) <- lcheck rig erase env val
            ty <- getTerm gty
            pure (TDelay fc r ty' val', gnf env (TDelayed fc r ty), u)
@@ -365,24 +361,24 @@ mutual
                  Binder (Term vars) ->
                  Core (Binder (Term vars), Glued vars, Usage vars)
   lcheckBinder rig erase env (Lam c x ty)
-      = do (tyv, tyt, _) <- lcheck Rig0 erase env ty
+      = do (tyv, tyt, _) <- lcheck erased erase env ty
            pure (Lam c x tyv, tyt, [])
   lcheckBinder rig erase env (Let rigc val ty)
-      = do (tyv, tyt, _) <- lcheck Rig0 erase env ty
-           (valv, valt, vs) <- lcheck (rigMult rig rigc) erase env val
+      = do (tyv, tyt, _) <- lcheck erased erase env ty
+           (valv, valt, vs) <- lcheck (rig |*| rigc) erase env val
            pure (Let rigc valv tyv, tyt, vs)
   lcheckBinder rig erase env (Pi c x ty)
-      = do (tyv, tyt, _) <- lcheck Rig0 erase env ty
+      = do (tyv, tyt, _) <- lcheck erased erase env ty
            pure (Pi c x tyv, tyt, [])
   lcheckBinder rig erase env (PVar c p ty)
-      = do (tyv, tyt, _) <- lcheck Rig0 erase env ty
+      = do (tyv, tyt, _) <- lcheck erased erase env ty
            pure (PVar c p tyv, tyt, [])
   lcheckBinder rig erase env (PLet rigc val ty)
-      = do (tyv, tyt, _) <- lcheck Rig0 erase env ty
-           (valv, valt, vs) <- lcheck (rigMult rig rigc) erase env val
+      = do (tyv, tyt, _) <- lcheck erased erase env ty
+           (valv, valt, vs) <- lcheck (rig |*| rigc) erase env val
            pure (PLet rigc valv tyv, tyt, vs)
   lcheckBinder rig erase env (PVTy c ty)
-      = do (tyv, tyt, _) <- lcheck Rig0 erase env ty
+      = do (tyv, tyt, _) <- lcheck erased erase env ty
            pure (PVTy c tyv, tyt, [])
 
   discharge : Defs -> Env Term vars ->
@@ -441,36 +437,34 @@ mutual
                      Core (List (Name, ArgUsage))
       getCaseUsage ty env (As _ _ _ p :: args) used rhs
           = getCaseUsage ty env (p :: args) used rhs
-      getCaseUsage (Bind _ n (Pi Rig1 e ty) sc) env (Local _ _ idx p :: args) used rhs
-          = do rest <- getCaseUsage sc env args used rhs
-               let used_in = count idx used
-               holeFound <- updateHoleUsage (used_in == 0) (MkVar p) [] rhs
-               let ause
-                   = if holeFound && used_in == 0
-                             then UseUnknown
-                             else if used_in == 0
-                                     then Use0
-                                     else Use1
-               pure ((n, ause) :: rest)
-      getCaseUsage (Bind _ n (Pi c e ty) sc) env (arg :: args) used rhs
-          = do rest <- getCaseUsage sc env args used rhs
-               case c of
-                    Rig0 => pure ((n, Use0) :: rest)
-                    Rig1 => pure ((n, UseKeep) :: rest)
-                    _ => pure ((n, UseKeep) :: rest)
+      getCaseUsage (Bind _ n (Pi rig e ty) sc) env (arg :: args) used rhs
+          = if isLinear rig
+               then case arg of
+                         (Local _ _ idx p) =>
+                           do rest <- getCaseUsage sc env args used rhs
+                              let used_in = count idx used
+                              holeFound <- updateHoleUsage (used_in == 0) (MkVar p) [] rhs
+                              let ause
+                                  = if holeFound && used_in == 0
+                                            then UseUnknown
+                                            else if used_in == 0
+                                                    then Use0
+                                                    else Use1
+                              pure ((n, ause) :: rest)
+                         _ => do elseCase
+               else elseCase
+          where
+            elseCase : Core (List (Name, ArgUsage))
+            elseCase = do rest <- getCaseUsage sc env args used rhs
+                          pure $ if isErased rig
+                             then ((n, Use0) :: rest)
+                             else ((n, UseKeep) :: rest)
       getCaseUsage tm env args used rhs = pure []
 
       checkUsageOK : FC -> Nat -> Name -> Bool -> RigCount -> Core ()
-      checkUsageOK fc used nm isloc Rig0 = pure ()
-      checkUsageOK fc used nm isloc RigW = pure ()
-      checkUsageOK fc used nm True Rig1
-          = if used > 1
-               then throw (LinearUsed fc used nm)
-               else pure ()
-      checkUsageOK fc used nm isloc Rig1
-          = if used == 1
-               then pure ()
-               else throw (LinearUsed fc used nm)
+      checkUsageOK fc used nm isloc rig
+          = when (isLinear rig && ((isloc && used > 1) || (not isloc && used /= 1)))
+                 (throw (LinearUsed fc used nm))
 
       -- Is the variable one of the lhs arguments; i.e. do we treat it as
       -- affine rather than linear
@@ -499,14 +493,13 @@ mutual
                holeFound <- if isLinear (multiplicity b)
                                then updateHoleUsage (used_in == 0) pos [] tm
                                else pure False
-               let used = case rigMult (multiplicity b) rig of
-                               Rig1 => if holeFound && used_in == 0
-                                          then 1
-                                          else used_in
-                               _ => used_in
+               let used = if isLinear ((multiplicity b) |*| rig) &&
+                             holeFound && used_in == 0
+                             then 1
+                             else used_in
                checkUsageOK (getLoc (binderType b))
                             used nm (isLocArg pos args)
-                                    (rigMult (multiplicity b) rig)
+                                    ((multiplicity b) |*| rig)
                checkEnvUsage {done = done ++ [nm]} rig env
                      (rewrite sym (appendAssociative done [nm] xs) in usage)
                      (rewrite sym (appendAssociative done [nm] xs) in args)
@@ -594,8 +587,8 @@ mutual
       updateUsage (u :: us) (Bind bfc n (Pi c e ty) sc)
           = let sc' = updateUsage us sc
                 c' = case u of
-                          Use0 => Rig0
-                          Use1 => Rig1 -- ignore usage elsewhere, we checked here
+                          Use0 => erased
+                          Use1 => linear -- ignore usage elsewhere, we checked here
                           UseUnknown => c -- don't know, assumed unchanged and update hole types
                           UseKeep => c -- matched here, so count usage elsewhere
                           UseAny => c in -- no constraint, so leave alone
@@ -603,10 +596,8 @@ mutual
       updateUsage _ ty = ty
 
       rigSafe : RigCount -> RigCount -> Core ()
-      rigSafe Rig1 RigW = throw (LinearMisuse fc !(getFullName n) Rig1 RigW)
-      rigSafe Rig0 RigW = throw (LinearMisuse fc !(getFullName n) Rig0 RigW)
-      rigSafe Rig0 Rig1 = throw (LinearMisuse fc !(getFullName n) Rig0 Rig1)
-      rigSafe _ _ = pure ()
+      rigSafe a b = when (a < b)
+                         (throw (LinearMisuse fc !(getFullName n) a b))
 
   expandMeta : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->
@@ -637,11 +628,11 @@ mutual
                NF vars -> Core (Term vars, Glued vars, Usage vars)
   lcheckMeta rig erase env fc n idx
              (arg :: args) chk (NBind _ _ (Pi rigf _ ty) sc)
-      = do let checkRig = rigMult rigf rig
+      = do let checkRig = rigf |*| rig
            (arg', gargTy, aused) <- lcheck checkRig erase env arg
            defs <- get Ctxt
            sc' <- sc defs (toClosure defaultOpts env arg')
-           let aerased = if erase && rigf == Rig0 then Erased fc False else arg'
+           let aerased = if erase && isErased rigf then Erased fc False else arg'
            (tm, gty, u) <- lcheckMeta rig erase env fc n idx args
                                       (aerased :: chk) sc'
            pure (tm, gty, aused ++ u)
@@ -672,23 +663,18 @@ checkEnvUsage fc rig {done} {vars = nm :: xs} (b :: env) usage tm
          holeFound <- if isLinear (multiplicity b)
                          then updateHoleUsage (used_in == 0) pos [] tm
                          else pure False
-         let used = case rigMult (multiplicity b) rig of
-                         Rig1 => if holeFound && used_in == 0
-                                    then 1
-                                    else used_in
-                         _ => used_in
-         checkUsageOK used (rigMult (multiplicity b) rig)
+         let used = if isLinear ((multiplicity b) |*| rig) &&
+                       holeFound && used_in == 0
+                       then 1
+                       else used_in
+         checkUsageOK used ((multiplicity b) |*| rig)
          checkEnvUsage {done = done ++ [nm]} fc rig env
                (rewrite sym (appendAssociative done [nm] xs) in usage)
                (rewrite sym (appendAssociative done [nm] xs) in tm)
   where
     checkUsageOK : Nat -> RigCount -> Core ()
-    checkUsageOK used Rig0 = pure ()
-    checkUsageOK used RigW = pure ()
-    checkUsageOK used Rig1
-        = if used == 1
-             then pure ()
-             else throw (LinearUsed fc used nm)
+    checkUsageOK used r = when (isLinear r && used /= 1)
+                               (throw (LinearUsed fc used nm))
 
 -- Linearity check an elaborated term. If 'erase' is set, erase anything that's in
 -- a Rig0 argument position (we can't do this until typechecking is complete, though,

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -358,7 +358,7 @@ parameters (defs : Defs, topopts : EvalOpts)
        --   + It's inlinable and we're in 'tcInline'
         = if alwaysReduce r
              || (not (holesOnly opts || argHolesOnly opts || tcInline opts))
-             || (meta && rigd /= Rig0)
+             || (meta && not (isErased rigd))
              || (meta && holesOnly opts)
              || (tcInline opts && elem TCInline flags)
              then case argsFromStack args stk of
@@ -715,8 +715,8 @@ mutual
 
   -- Comparing multiplicities when converting pi binders
   subRig : RigCount -> RigCount -> Bool
-  subRig Rig1 RigW = True -- we can pass a linear function if a general one is expected
-  subRig x y = x == y -- otherwise, the multiplicities need to match up
+  subRig x y = (isLinear x && isRigOther y) ||
+               x == y
 
   convBinders : Ref QVar Int -> Defs -> Env Term vars ->
                 Binder (NF vars) -> Binder (NF vars) -> Core Bool

--- a/src/Core/Primitives.idr
+++ b/src/Core/Primitives.idr
@@ -281,9 +281,9 @@ doubleTy = predTy DoubleType DoubleType
 
 believeMeTy : ClosedTerm
 believeMeTy
-    = Bind emptyFC (UN "a") (Pi Rig0 Explicit (TType emptyFC)) $
-      Bind emptyFC (UN "b") (Pi Rig0 Explicit (TType emptyFC)) $
-      Bind emptyFC (UN "x") (Pi RigW Explicit (Local emptyFC Nothing _ (Later First))) $
+    = Bind emptyFC (UN "a") (Pi erased Explicit (TType emptyFC)) $
+      Bind emptyFC (UN "b") (Pi erased Explicit (TType emptyFC)) $
+      Bind emptyFC (UN "x") (Pi top Explicit (Local emptyFC Nothing _ (Later First))) $
       Local emptyFC Nothing _ (Later First)
 
 castTo : Constant -> Vect 1 (NF vars) -> Maybe (NF vars)

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -5,6 +5,7 @@ import public Core.Name
 
 import Data.NameMap
 import Data.Vect
+import public Algebra
 
 %default covering
 
@@ -216,59 +217,6 @@ Eq t => Eq (PiInfo t) where
   (==) _ _ = False
 
 public export
-data RigCount = Rig0 | Rig1 | RigW
-
-export
-isLinear : RigCount -> Bool
-isLinear Rig1 = True
-isLinear _ = False
-
-export
-Eq RigCount where
-  (==) Rig0 Rig0 = True
-  (==) Rig1 Rig1 = True
-  (==) RigW RigW = True
-  (==) _ _ = False
-
-export
-Ord RigCount where
-  compare Rig0 Rig0 = EQ
-  compare Rig0 Rig1 = LT
-  compare Rig0 RigW = LT
-
-  compare Rig1 Rig0 = GT
-  compare Rig1 Rig1 = EQ
-  compare Rig1 RigW = LT
-
-  compare RigW Rig0 = GT
-  compare RigW Rig1 = GT
-  compare RigW RigW = EQ
-
-export
-Show RigCount where
-  show Rig0 = "Rig0"
-  show Rig1 = "Rig1"
-  show RigW = "RigW"
-
-fromInt : Int -> RigCount
-fromInt 0 = Rig0
-fromInt 1 = Rig1
-fromInt _ = RigW
-
-toInt : RigCount -> Int
-toInt Rig0 = 0
-toInt Rig1 = 1
-toInt RigW = 2
-
-export
-rigPlus : RigCount -> RigCount -> RigCount
-rigPlus a b = fromInt (toInt a + toInt b)
-
-export
-rigMult : RigCount -> RigCount -> RigCount
-rigMult a b = fromInt (toInt a * toInt b)
-
-public export
 data Binder : Type -> Type where
 	   -- Lambda bound variables with their implicitness
      Lam : RigCount -> PiInfo type -> (ty : type) -> Binder type
@@ -314,18 +262,13 @@ setMultiplicity (PVar c p ty) c' = PVar c' p ty
 setMultiplicity (PLet c val ty) c' = PLet c' val ty
 setMultiplicity (PVTy c ty) c' = PVTy c' ty
 
-showCount : RigCount -> String
-showCount Rig0 = "0 "
-showCount Rig1 = "1 "
-showCount RigW = ""
-
 Show ty => Show (Binder ty) where
-	show (Lam c _ t) = "\\" ++ showCount c ++ show t
-	show (Pi c _ t) = "Pi " ++ showCount c ++ show t
-	show (Let c v t) = "let " ++ showCount c ++ show v ++ " : " ++ show t
-	show (PVar c _ t) = "pat " ++ showCount c ++ show t
-	show (PLet c v t) = "plet " ++ showCount c ++ show v ++ " : " ++ show t
-	show (PVTy c t) = "pty " ++ showCount c ++ show t
+	show (Lam c _ t) = "\\" ++ show c ++ show t
+	show (Pi c _ t) = "Pi " ++ show c ++ show t
+	show (Let c v t) = "let " ++ show c ++ show v ++ " : " ++ show t
+	show (PVar c _ t) = "pat " ++ show c ++ show t
+	show (PLet c v t) = "plet " ++ show c ++ show v ++ " : " ++ show t
+	show (PVTy c t) = "pty " ++ show c ++ show t
 
 export
 setType : Binder tm -> tm -> Binder tm
@@ -812,11 +755,11 @@ apply loc fn (a :: args) = apply loc (App loc fn a) args
 -- Build a simple function type
 export
 fnType : Term vars -> Term vars -> Term vars
-fnType arg scope = Bind emptyFC (MN "_" 0) (Pi RigW Explicit arg) (weaken scope)
+fnType arg scope = Bind emptyFC (MN "_" 0) (Pi top Explicit arg) (weaken scope)
 
 export
 linFnType : Term vars -> Term vars -> Term vars
-linFnType arg scope = Bind emptyFC (MN "_" 0) (Pi Rig1 Explicit arg) (weaken scope)
+linFnType arg scope = Bind emptyFC (MN "_" 0) (Pi timesNeutral Explicit arg) (weaken scope)
 
 export
 getFnArgs : Term vars -> (Term vars, List (Term vars))
@@ -1271,6 +1214,11 @@ nameAt : {vars : _} ->
          (idx : Nat) -> .(p : IsVar n idx vars) -> Name
 nameAt {vars = n :: ns} Z First = n
 nameAt {vars = n :: ns} (S k) (Later p) = nameAt k p
+
+showCount : RigCount -> String
+showCount = elimSemi "0 "
+                     "1 "
+                     (const "")
 
 export Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -262,13 +262,16 @@ setMultiplicity (PVar c p ty) c' = PVar c' p ty
 setMultiplicity (PLet c val ty) c' = PLet c' val ty
 setMultiplicity (PVTy c ty) c' = PVTy c' ty
 
+showCount : RigCount -> String
+showCount = elimSemi "0 " "1 " (const "")
+
 Show ty => Show (Binder ty) where
-	show (Lam c _ t) = "\\" ++ show c ++ show t
-	show (Pi c _ t) = "Pi " ++ show c ++ show t
-	show (Let c v t) = "let " ++ show c ++ show v ++ " : " ++ show t
-	show (PVar c _ t) = "pat " ++ show c ++ show t
-	show (PLet c v t) = "plet " ++ show c ++ show v ++ " : " ++ show t
-	show (PVTy c t) = "pty " ++ show c ++ show t
+	show (Lam c _ t) = "\\" ++ showCount c ++ show t
+	show (Pi c _ t) = "Pi " ++ showCount c ++ show t
+	show (Let c v t) = "let " ++ showCount c ++ show v ++ " : " ++ show t
+	show (PVar c _ t) = "pat " ++ showCount c ++ show t
+	show (PLet c v t) = "plet " ++ showCount c ++ show v ++ " : " ++ show t
+	show (PVTy c t) = "pty " ++ showCount c ++ show t
 
 export
 setType : Binder tm -> tm -> Binder tm
@@ -759,7 +762,7 @@ fnType arg scope = Bind emptyFC (MN "_" 0) (Pi top Explicit arg) (weaken scope)
 
 export
 linFnType : Term vars -> Term vars -> Term vars
-linFnType arg scope = Bind emptyFC (MN "_" 0) (Pi timesNeutral Explicit arg) (weaken scope)
+linFnType arg scope = Bind emptyFC (MN "_" 0) (Pi linear Explicit arg) (weaken scope)
 
 export
 getFnArgs : Term vars -> (Term vars, List (Term vars))
@@ -1214,11 +1217,6 @@ nameAt : {vars : _} ->
          (idx : Nat) -> .(p : IsVar n idx vars) -> Name
 nameAt {vars = n :: ns} Z First = n
 nameAt {vars = n :: ns} (S k) (Later p) = nameAt k p
-
-showCount : RigCount -> String
-showCount = elimSemi "0 "
-                     "1 "
-                     (const "")
 
 export Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -73,15 +73,16 @@ TTC Name where
 
 export
 TTC RigCount where
-  toBuf b Rig0 = tag 0
-  toBuf b Rig1 = tag 1
-  toBuf b RigW = tag 2
+  toBuf b = elimSemi
+              (tag 0)
+              (tag 1)
+              (const $ tag 2)
 
   fromBuf b
       = case !getTag of
-             0 => pure Rig0
-             1 => pure Rig1
-             2 => pure RigW
+             0 => pure erased
+             1 => pure linear
+             2 => pure top
              _ => corrupt "RigCount"
 
 export
@@ -946,7 +947,7 @@ TTC GlobalDef where
                                         mul vars vis
                                         tot fl refs refsR inv c True def cdef Nothing sc)
               else pure (MkGlobalDef loc name (Erased loc False) [] [] []
-                                     RigW [] Public unchecked [] refs refsR
+                                     top [] Public unchecked [] refs refsR
                                      False False True def cdef Nothing [])
 
 TTC Transform where

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -413,12 +413,12 @@ instantiate {newvars} loc mode env mname mref num mdef locs otm tm
         updateLocsB (Let c v t) = Just (Let c !(updateLocs locs v) !(updateLocs locs t))
         -- Make 'pi' binders have multiplicity W when we infer a Rig1 metavariable,
         -- since this is the most general thing to do if it's unknown.
-        updateLocsB (Pi Rig1 p t)
-            = do t' <- updateLocs locs t
-                 if inLam mode
-                    then Just (Pi Rig1 p t')
-                    else Just (Pi RigW p t')
-        updateLocsB (Pi c p t) = Just (Pi c p !(updateLocs locs t))
+        updateLocsB (Pi rig p t) = if isLinear rig
+            then  do t' <- updateLocs locs t
+                     pure $ if inLam mode
+                        then (Pi linear p t')
+                        else (Pi top p t')
+            else Just (Pi rig p !(updateLocs locs t))
         updateLocsB (PVar c p t) = Just (PVar c p !(updateLocs locs t))
         updateLocsB (PLet c v t) = Just (PLet c !(updateLocs locs v) !(updateLocs locs t))
         updateLocsB (PVTy c t) = Just (PVTy c !(updateLocs locs t))
@@ -856,8 +856,8 @@ mutual
 
   -- Comparing multiplicities when converting pi binders
   subRig : RigCount -> RigCount -> Bool
-  subRig Rig1 RigW = True -- we can pass a linear function if a general one is expected
-  subRig x y = x == y -- otherwise, the multiplicities need to match up
+  subRig x y = (isLinear x && isRigOther y) || -- we can pass a linear function if a general one is expected
+               x == y -- otherwise, the multiplicities need to match up
 
   unifyBothBinders: {auto c : Ref Ctxt Defs} ->
                     {auto u : Ref UST UState} ->
@@ -894,7 +894,7 @@ mutual
                       cs => -- Constraints, make new guarded constant
                          do txtm <- quote empty env tx
                             tytm <- quote empty env ty
-                            c <- newConstant loc Rig0 env
+                            c <- newConstant loc erased env
                                    (Bind xfc x (Lam cy Explicit txtm) (Local xfc Nothing _ First))
                                    (Bind xfc x (Pi cy Explicit txtm)
                                        (weaken tytm)) cs

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -35,7 +35,7 @@ bindConstraints : FC -> PiInfo RawImp ->
                   List (Maybe Name, RawImp) -> RawImp -> RawImp
 bindConstraints fc p [] ty = ty
 bindConstraints fc p ((n, ty) :: rest) sc
-    = IPi fc RigW p n ty (bindConstraints fc p rest sc)
+    = IPi fc top p n ty (bindConstraints fc p rest sc)
 
 bindImpls : FC -> List (Name, RigCount, RawImp) -> RawImp -> RawImp
 bindImpls fc [] ty = ty
@@ -146,7 +146,7 @@ elabImplementation {vars} fc vis pass env nest is cons iname ps impln nusing mbo
                           else []
          let impTy = doBind paramBinds initTy
 
-         let impTyDecl = IClaim fc RigW vis opts (MkImpTy fc impName impTy)
+         let impTyDecl = IClaim fc top vis opts (MkImpTy fc impName impTy)
          log 5 $ "Implementation type: " ++ show impTy
 
          when (typePass pass) $ processDecl [] nest env impTyDecl

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -80,21 +80,21 @@ perror (NotTotal fc n r)
     = pure $ !(prettyName n) ++ " is not total"
 perror (LinearUsed fc count n)
     = pure $ "There are " ++ show count ++ " uses of linear name " ++ sugarName n
-perror (LinearMisuse fc n Rig0 ctx)
-    = pure $ show n ++ " is not accessible in this context"
 perror (LinearMisuse fc n exp ctx)
-    = pure $ "Trying to use " ++ showRig exp ++ " name " ++ sugarName n ++
+    = pure $ if isErased exp
+         then show n ++ " is not accessible in this context"
+         else "Trying to use " ++ showRig exp ++ " name " ++ sugarName n ++
                  " in " ++ showRel ctx ++ " context"
   where
     showRig : RigCount -> String
-    showRig Rig0 = "irrelevant"
-    showRig Rig1 = "linear"
-    showRig RigW = "unrestricted"
+    showRig = elimSemi "irrelevant"
+                       "linear"
+                       (const "unrestricted")
 
     showRel : RigCount -> String
-    showRel Rig0 = "irrelevant"
-    showRel Rig1 = "relevant"
-    showRel RigW = "non-linear"
+    showRel = elimSemi "irrelevant"
+                       "relevant"
+                       (const "non-linear")
 perror (BorrowPartial fc env tm arg)
     = pure $ !(pshow env tm) ++
              " borrows argument " ++ !(pshow env arg) ++

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -374,9 +374,9 @@ mutual
     <|> pure Nothing
 
   getMult : Maybe Integer -> EmptyRule RigCount
-  getMult (Just 0) = pure Rig0
-  getMult (Just 1) = pure Rig1
-  getMult Nothing = pure RigW
+  getMult (Just 0) = pure erased
+  getMult (Just 1) = pure linear
+  getMult Nothing = pure top
   getMult _ = fatalError "Invalid multiplicity (must be 0 or 1)"
 
   pibindAll : FC -> PiInfo PTerm -> List (RigCount, Maybe Name, PTerm) ->
@@ -477,7 +477,7 @@ mutual
            ns <- sepBy1 (symbol ",") unqualifiedName
            nend <- location
            let nfc = MkFC fname nstart nend
-           let binders = map (\n => (Rig0, Just (UN n), PImplicit nfc)) ns
+           let binders = map (\n => (erased, Just (UN n), PImplicit nfc)) ns
            symbol "."
            scope <- typeExpr pdef fname indents
            end <- location
@@ -591,7 +591,7 @@ mutual
            let fcCase = MkFC fname start endCase
            let n = MN "lcase" 0
            pure $
-            PLam fcCase RigW Explicit (PRef fcCase n) (PInfer fcCase) $
+            PLam fcCase top Explicit (PRef fcCase n) (PInfer fcCase) $
                 PCase fc (PRef fcCase n) alts
 
   caseAlt : FileName -> IndentInfo -> Rule PClause
@@ -767,7 +767,7 @@ mutual
       mkPi : FilePos -> FilePos -> PTerm -> List (PiInfo PTerm, PTerm) -> PTerm
       mkPi start end arg [] = arg
       mkPi start end arg ((exp, a) :: as)
-            = PPi (MkFC fname start end) RigW exp Nothing arg
+            = PPi (MkFC fname start end) top exp Nothing arg
                   (mkPi start end a as)
 
   export
@@ -849,20 +849,20 @@ mutual
 mkTyConType : FC -> List Name -> PTerm
 mkTyConType fc [] = PType fc
 mkTyConType fc (x :: xs)
-   = PPi fc Rig1 Explicit Nothing (PType fc) (mkTyConType fc xs)
+   = PPi fc linear Explicit Nothing (PType fc) (mkTyConType fc xs)
 
 mkDataConType : FC -> PTerm -> List ArgType -> PTerm
 mkDataConType fc ret [] = ret
 mkDataConType fc ret (ExpArg x :: xs)
-    = PPi fc Rig1 Explicit Nothing x (mkDataConType fc ret xs)
+    = PPi fc linear Explicit Nothing x (mkDataConType fc ret xs)
 mkDataConType fc ret (ImpArg n (PRef fc' x) :: xs)
     = if n == Just x
-         then PPi fc Rig1 Implicit n (PType fc')
+         then PPi fc linear Implicit n (PType fc')
                           (mkDataConType fc ret xs)
-         else PPi fc Rig1 Implicit n (PRef fc' x)
+         else PPi fc linear Implicit n (PRef fc' x)
                           (mkDataConType fc ret xs)
 mkDataConType fc ret (ImpArg n x :: xs)
-    = PPi fc Rig1 Implicit n x (mkDataConType fc ret xs)
+    = PPi fc linear Implicit n x (mkDataConType fc ret xs)
 mkDataConType fc ret (WithArg a :: xs)
     = PImplicit fc -- This can't happen because we parse constructors without
                    -- withOK set
@@ -1260,9 +1260,7 @@ fieldDecl fname indents
         = do start <- location
              m <- multiplicity
              rigin <- getMult m
-             let rig = case rigin of
-                            Rig0 => Rig0
-                            _ => Rig1
+             let rig = if isErased rigin then erased else linear
              ns <- sepBy1 (symbol ",") name
              symbol ":"
              ty <- expr pdef fname indents
@@ -1279,7 +1277,7 @@ recordParam fname indents
   <|> do symbol "{"
          commit
          info <- the (EmptyRule (PiInfo PTerm))
-                 (pure  AutoImplicit <* keyword "auto" 
+                 (pure  AutoImplicit <* keyword "auto"
               <|>(do
                   keyword "default"
                   t <- simpleExpr fname indents
@@ -1292,7 +1290,7 @@ recordParam fname indents
   <|> do start <- location
          n <- name
          end <- location
-         pure [(n, RigW, Explicit, PInfer (MkFC fname start end))]
+         pure [(n, top, Explicit, PInfer (MkFC fname start end))]
 
 recordDecl : FileName -> IndentInfo -> Rule PDecl
 recordDecl fname indents

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -338,9 +338,10 @@ record Module where
   decls : List PDecl
 
 showCount : RigCount -> String
-showCount Rig0 = "0 "
-showCount Rig1 = "1 "
-showCount RigW = ""
+showCount = elimSemi
+                ("0 ")
+                ("1 ")
+                (const "")
 
 mutual
   showAlt : PClause -> String
@@ -372,15 +373,15 @@ mutual
     showPrec d (PPi _ rig Explicit Nothing arg ret)
         = showPrec d arg ++ " -> " ++ showPrec d ret
     showPrec d (PPi _ rig Explicit (Just n) arg ret)
-        = "(" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ ") -> " ++ showPrec d ret
+        = "(" ++ Syntax.showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ ") -> " ++ showPrec d ret
     showPrec d (PPi _ rig Implicit Nothing arg ret) -- shouldn't happen
-        = "{" ++ showCount rig ++ "_ : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
+        = "{" ++ Syntax.showCount rig ++ "_ : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
     showPrec d (PPi _ rig Implicit (Just n) arg ret)
-        = "{" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
-    showPrec d (PPi _ RigW AutoImplicit Nothing arg ret)
+        = "{" ++ Syntax.showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
+    showPrec d (PPi _ top AutoImplicit Nothing arg ret)
         = showPrec d arg ++ " => " ++ showPrec d ret
     showPrec d (PPi _ rig AutoImplicit Nothing arg ret) -- shouldn't happen
-        = "{auto " ++ showCount rig ++ "_ : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
+        = "{auto " ++ Syntax.showCount rig ++ "_ : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
     showPrec d (PPi _ rig AutoImplicit (Just n) arg ret)
         = "{auto " ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
     showPrec d (PPi _ rig (DefImplicit t) Nothing arg ret) -- shouldn't happen
@@ -388,13 +389,13 @@ mutual
     showPrec d (PPi _ rig (DefImplicit t) (Just n) arg ret)
         = "{default " ++ showPrec App t ++ " " ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
     showPrec d (PLam _ rig _ n (PImplicit _) sc)
-        = "\\" ++ showCount rig ++ showPrec d n ++ " => " ++ showPrec d sc
+        = "\\" ++ Syntax.showCount rig ++ showPrec d n ++ " => " ++ showPrec d sc
     showPrec d (PLam _ rig _ n ty sc)
-        = "\\" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ " => " ++ showPrec d sc
+        = "\\" ++ Syntax.showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ " => " ++ showPrec d sc
     showPrec d (PLet _ rig n (PImplicit _) val sc alts)
-        = "let " ++ showCount rig ++ showPrec d n ++ " = " ++ showPrec d val ++ " in " ++ showPrec d sc
+        = "let " ++ Syntax.showCount rig ++ showPrec d n ++ " = " ++ showPrec d val ++ " in " ++ showPrec d sc
     showPrec d (PLet _ rig n ty val sc alts)
-        = "let " ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ " = "
+        = "let " ++ Syntax.showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ " = "
                  ++ showPrec d val ++ concatMap showAlt alts ++
                  " in " ++ showPrec d sc
       where

--- a/src/TTImp/BindImplicits.idr
+++ b/src/TTImp/BindImplicits.idr
@@ -118,17 +118,17 @@ bindNames arg tm
 -- if the name is part of the using decls, add the relevant binder for it:
 -- either an implicit pi binding, if there's a name, or an autoimplicit type
 -- binding if the name just appears as part of the type
-getUsing : Name -> List (Int, Maybe Name, RawImp) -> 
+getUsing : Name -> List (Int, Maybe Name, RawImp) ->
            List (Int, (RigCount, PiInfo RawImp, Maybe Name, RawImp))
 getUsing n [] = []
 getUsing n ((t, Just n', ty) :: us) -- implicit binder
     = if n == n'
-         then (t, (Rig0, Implicit, Just n, ty)) :: getUsing n us
+         then (t, (erased, Implicit, Just n, ty)) :: getUsing n us
          else getUsing n us
 getUsing n ((t, Nothing, ty) :: us) -- autoimplicit binder
     = let ns = nub (findIBindVars ty) in
           if n `elem` ns
-             then (t, (RigW, AutoImplicit, Nothing, ty)) ::
+             then (t, (top, AutoImplicit, Nothing, ty)) ::
                       getUsing n us
              else getUsing n us
 
@@ -183,5 +183,5 @@ piBindNames loc env tm
     piBind : List String -> RawImp -> RawImp
     piBind [] ty = ty
     piBind (n :: ns) ty
-       = IPi loc Rig0 Implicit (Just (UN n)) (Implicit loc False) (piBind ns ty)
+       = IPi loc erased Implicit (Just (UN n)) (Implicit loc False) (piBind ns ty)
 

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -305,7 +305,7 @@ checkAlternative : {vars : _} ->
 checkAlternative rig elabinfo nest env fc (UniqueDefault def) alts mexpected
     = do checkAmbigDepth fc elabinfo
          expected <- maybe (do nm <- genName "altTy"
-                               ty <- metaVar fc Rig0 env nm (TType fc)
+                               ty <- metaVar fc erased env nm (TType fc)
                                pure (gnf env ty))
                            pure mexpected
          let solvemode = case elabMode elabinfo of
@@ -355,7 +355,7 @@ checkAlternative rig elabinfo nest env fc uniq alts mexpected
            [alt] => checkImp rig elabinfo nest env alt mexpected
            _ =>
              do expected <- maybe (do nm <- genName "altTy"
-                                      ty <- metaVar fc Rig0 env nm (TType fc)
+                                      ty <- metaVar fc erased env nm (TType fc)
                                       pure (gnf env ty))
                                   pure mexpected
                 let solvemode = case elabMode elabinfo of

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -65,10 +65,8 @@ getNameType rigc env fc x
     isLet _ = False
 
     rigSafe : RigCount -> RigCount -> Core ()
-    rigSafe Rig1 RigW = throw (LinearMisuse fc !(getFullName x) Rig1 RigW)
-    rigSafe Rig0 RigW = throw (LinearMisuse fc !(getFullName x) Rig0 RigW)
-    rigSafe Rig0 Rig1 = throw (LinearMisuse fc !(getFullName x) Rig0 Rig1)
-    rigSafe _ _ = pure ()
+    rigSafe lhs rhs = when (lhs < rhs)
+                           (throw (LinearMisuse fc !(getFullName x) lhs rhs))
 
 -- Get the type of a variable, looking it up in the nested names first.
 getVarType : {vars : _} ->
@@ -210,7 +208,7 @@ mutual
                     RigCount -> RigCount -> ElabInfo ->
                     NestedNames vars -> Env Term vars ->
                     FC -> (fntm : Term vars) ->
-                    Name -> NF vars -> NF vars -> 
+                    Name -> NF vars -> NF vars ->
                     (Defs -> Closure vars -> Core (NF vars)) ->
                     (argpos : (Maybe Name, Nat)) ->
                     (expargs : List RawImp) ->
@@ -296,28 +294,29 @@ mutual
   checkPatTyValid fc defs env (NApp _ (NMeta n i _) _) arg got
       = do Just gdef <- lookupCtxtExact (Resolved i) (gamma defs)
                 | Nothing => pure ()
-           case multiplicity gdef of
-                Rig0 =>
-                   do -- Argument is only valid if gotnf is not a concrete type
+           if isErased (multiplicity gdef)
+              then do -- Argument is only valid if gotnf is not a concrete type
                       gotnf <- getNF got
                       if !(concrete defs env gotnf)
                          then throw (MatchTooSpecific fc env arg)
                          else pure ()
-                _ => pure ()
+              else pure ()
   checkPatTyValid fc defs env _ _ _ = pure ()
 
   dotErased : {auto c : Ref Ctxt Defs} ->
               Maybe Name -> Nat -> ElabMode -> RigCount -> RawImp -> Core RawImp
-  dotErased _ _ (InLHS Rig0) r tm = pure $ tm
-  dotErased mn argpos (InLHS _) Rig0 tm
-      = -- if argpos is an erased position of 'n', leave it, otherwise dot if
-        -- necessary
-        do defs <- get Ctxt
-           Just gdef <- maybe (pure Nothing) (\n => lookupCtxtExact n (gamma defs)) mn
-                | Nothing => pure (dotTerm tm)
-           if argpos `elem` safeErase gdef
-              then pure tm
-              else pure $ dotTerm tm
+  dotErased mn argpos (InLHS lrig ) rig tm
+      = if not (isErased lrig) && isErased rig
+           then
+                -- if argpos is an erased position of 'n', leave it, otherwise dot if
+                -- necessary
+                do defs <- get Ctxt
+                   Just gdef <- maybe (pure Nothing) (\n => lookupCtxtExact n (gamma defs)) mn
+                        | Nothing => pure (dotTerm tm)
+                   if argpos `elem` safeErase gdef
+                      then pure tm
+                      else pure $ dotTerm tm
+           else pure tm
     where
       dotTerm : RawImp -> RawImp
       dotTerm tm
@@ -329,7 +328,7 @@ mutual
                  IAs _ _ _ (Implicit _ _) => tm
                  IAs fc p t arg => IAs fc p t (IMustUnify fc ErasedArg tm)
                  _ => IMustUnify (getFC tm) ErasedArg tm
-  dotErased _ _ _ r tm = pure $ tm
+  dotErased _ _ _ _ tm = pure tm
 
   -- Check the rest of an application given the argument type and the
   -- raw argument. We choose elaboration order depending on whether we know
@@ -445,7 +444,7 @@ mutual
   -- Ordinary explicit argument
   checkAppWith rig elabinfo nest env fc tm (NBind tfc x (Pi rigb Explicit aty) sc)
                argdata (arg :: expargs) impargs kr expty
-      = do let argRig = rigMult rig rigb
+      = do let argRig = rig |*| rigb
            checkRestApp rig argRig elabinfo nest env fc
                         tm x aty sc argdata arg expargs impargs kr expty
   -- Function type is delayed, so force the term and continue
@@ -455,7 +454,7 @@ mutual
   -- the expected type line up, stop
   checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi rigb Implicit aty) sc)
                argdata [] [] kr (Just expty_in)
-      = do let argRig = rigMult rig rigb
+      = do let argRig = rig |*| rigb
            expty <- getNF expty_in
            defs <- get Ctxt
            case expty of
@@ -469,7 +468,7 @@ mutual
                                (\err => makeImplicit rig argRig elabinfo nest env fc tm x aty sc argdata [] [] kr (Just expty_in))
   checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi rigb AutoImplicit aty) sc)
                argdata [] [] kr (Just expty_in)
-      = do let argRig = rigMult rig rigb
+      = do let argRig = rig |*| rigb
            expty <- getNF expty_in
            defs <- get Ctxt
            case expty of
@@ -491,7 +490,7 @@ mutual
   -- Check next auto implicit argument
   checkAppWith rig elabinfo nest env fc tm (NBind tfc x (Pi rigb AutoImplicit aty) sc)
                argdata expargs impargs kr expty
-      = let argRig = rigMult rig rigb in
+      = let argRig = rig |*| rigb in
             case useAutoImp [] impargs of
                Nothing => makeAutoImplicit rig argRig elabinfo nest env fc tm
                                            x aty sc argdata expargs impargs kr expty
@@ -513,7 +512,7 @@ mutual
   -- Check next implicit argument
   checkAppWith rig elabinfo nest env fc tm (NBind tfc x (Pi rigb Implicit aty) sc)
                argdata expargs impargs kr expty
-      = let argRig = rigMult rig rigb in
+      = let argRig = rig |*| rigb in
             case useImp [] impargs of
                Nothing => makeImplicit rig argRig elabinfo nest env fc tm
                                        x aty sc argdata expargs impargs kr expty
@@ -571,17 +570,17 @@ mutual
            logTerm 10 "Function " tm
            argn <- genName "argTy"
            retn <- genName "retTy"
-           argTy <- metaVar fc Rig0 env argn (TType fc)
+           argTy <- metaVar fc erased env argn (TType fc)
            let argTyG = gnf env argTy
            retTy <- metaVar -- {vars = argn :: vars}
-                            fc Rig0 env -- (Pi RigW Explicit argTy :: env)
+                            fc erased env -- (Pi RigW Explicit argTy :: env)
                             retn (TType fc)
            (argv, argt) <- check rig elabinfo
                                  nest env arg (Just argTyG)
            let fntm = App fc tm argv
            defs <- get Ctxt
            fnty <- nf defs env retTy -- (Bind fc argn (Let RigW argv argTy) retTy)
-           let expfnty = gnf env (Bind fc argn (Pi RigW Explicit argTy) (weaken retTy))
+           let expfnty = gnf env (Bind fc argn (Pi top Explicit argTy) (weaken retTy))
            logGlue 10 "Expected function type" env expfnty
            maybe (pure ()) (logGlue 10 "Expected result type" env) expty
            res <- checkAppWith rig elabinfo nest env fc fntm fnty (n, 1 + argpos) expargs impargs kr expty
@@ -620,7 +619,7 @@ checkApp rig elabinfo nest env fc (IVar fc' n) expargs impargs exp
                                                  etynf <- normaliseHoles defs env ety
                                                  pure (Just !(toFullNames etynf)))
                                        exp
-                    pure ("Checking application of " ++ show !(getFullName n) ++ 
+                    pure ("Checking application of " ++ show !(getFullName n) ++
                           " (" ++ show n ++ ")" ++
                           " to " ++ show expargs ++ "\n\tFunction type " ++
                           (show !(toFullNames fnty)) ++ "\n\tExpected app type "

--- a/src/TTImp/Elab/As.idr
+++ b/src/TTImp/Elab/As.idr
@@ -58,15 +58,15 @@ checkAs rig elabinfo nest env fc side n_in pat topexp
     -- to be the new variable (UseRight), but in generated case blocks it's
     -- better if it's the pattern (UseLeft)
     rigPat' : UseSide -> RigCount
-    rigPat' UseLeft = if rig == Rig1 then Rig1 else rig
-    rigPat' UseRight = if rig == Rig1 then Rig0 else rig
+    rigPat' UseLeft = if isLinear rig then linear else rig
+    rigPat' UseRight = if isLinear rig then erased else rig
 
     rigPat : RigCount
     rigPat = rigPat' side
 
     rigAs' : UseSide -> RigCount
-    rigAs' UseLeft = if rig == Rig1 then Rig0 else rig
-    rigAs' UseRight = if rig == Rig1 then Rig1 else rig
+    rigAs' UseLeft = if isLinear rig then erased else rig
+    rigAs' UseRight = if isLinear rig then linear else rig
 
     rigAs : RigCount
     rigAs = rigAs' side

--- a/src/TTImp/Elab/Case.idr
+++ b/src/TTImp/Elab/Case.idr
@@ -50,13 +50,13 @@ findLater {older} x (_ :: xs)
 
 toRig1 : {idx : Nat} -> .(IsVar name idx vs) -> Env Term vs -> Env Term vs
 toRig1 First (b :: bs)
-    = if multiplicity b == Rig0
-         then setMultiplicity b Rig1 :: bs
+    = if isErased (multiplicity b)
+         then setMultiplicity b linear :: bs
          else b :: bs
 toRig1 (Later p) (b :: bs) = b :: toRig1 p bs
 
 toRig0 : {idx : Nat} -> .(IsVar name idx vs) -> Env Term vs -> Env Term vs
-toRig0 First (b :: bs) = setMultiplicity b Rig0 :: bs
+toRig0 First (b :: bs) = setMultiplicity b erased :: bs
 toRig0 (Later p) (b :: bs) = b :: toRig0 p bs
 
 allow : Maybe (Var vs) -> Env Term vs -> Env Term vs
@@ -177,7 +177,7 @@ caseBlock {vars} rigc elabinfo fc nest env scr scrtm scrty caseRig alts expected
                            Just ty => getTerm ty
                            _ =>
                               do nmty <- genName "caseTy"
-                                 metaVar fc Rig0 env nmty (TType fc)
+                                 metaVar fc erased env nmty (TType fc)
 
          (caseretty, _) <- bindImplicits fc (implicitMode elabinfo) defs env
                                          fullImps caseretty_in (TType fc)
@@ -196,7 +196,7 @@ caseBlock {vars} rigc elabinfo fc nest env scr scrtm scrty caseRig alts expected
          -- actually bound! This is rather hacky, but a lot less fiddly than
          -- the alternative of fixing up the environment
          when (not (isNil fullImps)) $ findImpsIn fc [] [] casefnty
-         cidx <- addDef casen (newDef fc casen (if rigc == Rig0 then Rig0 else RigW)
+         cidx <- addDef casen (newDef fc casen (if isErased rigc then erased else top)
                                       [] casefnty Private None)
          let caseRef : Term vars = Ref fc Func (Resolved cidx)
 
@@ -222,7 +222,7 @@ caseBlock {vars} rigc elabinfo fc nest env scr scrtm scrty caseRig alts expected
     mkLocalEnv [] = []
     mkLocalEnv (b :: bs)
         = let b' = if isLinear (multiplicity b)
-                      then setMultiplicity b Rig0
+                      then setMultiplicity b erased
                       else b in
               b' :: mkLocalEnv bs
 
@@ -326,25 +326,26 @@ checkCase rig elabinfo nest env fc scr scrty_in alts exp
         do scrty_exp <- case scrty_in of
                              Implicit _ _ => guessScrType alts
                              _ => pure scrty_in
-           (scrtyv, scrtyt) <- check Rig0 elabinfo nest env scrty_exp
+           (scrtyv, scrtyt) <- check erased elabinfo nest env scrty_exp
                                      (Just (gType fc))
            logTerm 10 "Expected scrutinee type" scrtyv
            -- Try checking at the given multiplicity; if that doesn't work,
            -- try checking at Rig1 (meaning that we're using a linear variable
            -- so the scrutinee should be linear)
-           let chrig = case rig of
-                            Rig0 => Rig0
-                            _ => RigW
+           let chrig = if isErased rig then erased else top
            log 5 $ "Checking " ++ show scr ++ " at " ++ show chrig
 
            (scrtm_in, gscrty, caseRig) <- handle
               (do c <- runDelays 10 $ check chrig elabinfo nest env scr (Just (gnf env scrtyv))
                   pure (fst c, snd c, chrig))
               (\err => case err of
-                            LinearMisuse _ _ Rig1 _
-                              => do c <- runDelays 10 $ check Rig1 elabinfo nest env scr
+                            e@(LinearMisuse _ _ r _)
+                              => branchOne
+                                    (do c <- runDelays 10 $ check linear elabinfo nest env scr
                                                (Just (gnf env scrtyv))
-                                    pure (fst c, snd c, Rig1)
+                                        pure (fst c, snd c, linear))
+                                    (throw e)
+                                    r
                             e => throw e)
 
            scrty <- getTerm gscrty

--- a/src/TTImp/Elab/Delayed.idr
+++ b/src/TTImp/Elab/Delayed.idr
@@ -60,7 +60,7 @@ delayOnFailure fc rig env expected pred pri elab
                  if pred err && allowDelay est
                     then
                       do nm <- genName "delayed"
-                         (ci, dtm) <- newDelayed fc Rig1 env nm !(getTerm expected)
+                         (ci, dtm) <- newDelayed fc linear env nm !(getTerm expected)
                          logGlueNF 5 ("Postponing elaborator " ++ show nm ++
                                       " at " ++ show fc ++
                                       " for") env expected
@@ -89,7 +89,7 @@ delayElab {vars} fc rig env exp pri elab
             else do
              nm <- genName "delayed"
              expected <- mkExpected exp
-             (ci, dtm) <- newDelayed fc Rig1 env nm !(getTerm expected)
+             (ci, dtm) <- newDelayed fc linear env nm !(getTerm expected)
              logGlueNF 5 ("Postponing elaborator " ++ show nm ++
                           " for") env expected
              ust <- get UST
@@ -102,7 +102,7 @@ delayElab {vars} fc rig env exp pri elab
     mkExpected (Just ty) = pure ty
     mkExpected Nothing
         = do nm <- genName "delayTy"
-             ty <- metaVar fc Rig0 env nm (TType fc)
+             ty <- metaVar fc erased env nm (TType fc)
              pure (gnf env ty)
 
 export

--- a/src/TTImp/Elab/Hole.idr
+++ b/src/TTImp/Elab/Hole.idr
@@ -45,7 +45,7 @@ checkHole rig elabinfo nest env fc n_in (Just gexpty)
 checkHole rig elabinfo nest env fc n_in exp
     = do nmty <- genName ("type_of_" ++ n_in)
          let env' = letToLam env
-         ty <- metaVar fc Rig0 env' nmty (TType fc)
+         ty <- metaVar fc erased env' nmty (TType fc)
          nm <- inCurrentNS (UN n_in)
          defs <- get Ctxt
          Nothing <- lookupCtxtExact nm (gamma defs)

--- a/src/TTImp/Elab/Lazy.idr
+++ b/src/TTImp/Elab/Lazy.idr
@@ -41,7 +41,7 @@ checkDelay : {vars : _} ->
              Core (Term vars, Glued vars)
 checkDelay rig elabinfo nest env fc tm mexpected
     = do expected <- maybe (do nm <- genName "delayTy"
-                               ty <- metaVar fc Rig0 env nm (TType fc)
+                               ty <- metaVar fc erased env nm (TType fc)
                                pure (gnf env ty))
                            pure mexpected
          let solvemode = case elabMode elabinfo of

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -46,7 +46,7 @@ checkLocal {vars} rig elabinfo nest env fc nestdecls scope expty
     dropLinear [] = []
     dropLinear (b :: bs)
         = if isLinear (multiplicity b)
-             then setMultiplicity b Rig0 :: dropLinear bs
+             then setMultiplicity b erased :: dropLinear bs
              else b :: dropLinear bs
 
     applyEnv : {auto c : Ref Ctxt Defs} -> Int -> Name ->

--- a/src/TTImp/Elab/Rewrite.idr
+++ b/src/TTImp/Elab/Rewrite.idr
@@ -78,7 +78,7 @@ elabRewrite loc env expected rulety
          logTerm 5 "Rewritten to" rwexp_sc
 
          empty <- clearDefs defs
-         let pred = Bind loc parg (Lam RigW Explicit
+         let pred = Bind loc parg (Lam top Explicit
                           !(quote empty env lty))
                           (refsToLocals (Add parg parg None) rwexp_sc)
          gpredty <- getType env pred
@@ -105,7 +105,7 @@ checkRewrite rigc elabinfo nest env fc rule tm Nothing
     = throw (GenericMsg fc "Can't infer a type for rewrite")
 checkRewrite {vars} rigc elabinfo nest env fc rule tm (Just expected)
     = delayOnFailure fc rigc env expected rewriteErr 10 (\delayed =>
-        do (rulev, grulet) <- check Rig0 elabinfo nest env rule Nothing
+        do (rulev, grulet) <- check erased elabinfo nest env rule Nothing
            rulet <- getTerm grulet
            expTy <- getTerm expected
            when delayed $ log 5 "Retrying rewrite"
@@ -114,8 +114,8 @@ checkRewrite {vars} rigc elabinfo nest env fc rule tm (Just expected)
            rname <- genVarName "_"
            pname <- genVarName "_"
 
-           let pbind = Let Rig0 pred predty
-           let rbind = Let Rig0 (weaken rulev) (weaken rulet)
+           let pbind = Let erased pred predty
+           let rbind = Let erased (weaken rulev) (weaken rulet)
 
            let env' = rbind :: pbind :: env
 

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -146,7 +146,7 @@ checkTerm rig elabinfo nest env (ISearch fc depth) (Just gexpty)
 checkTerm rig elabinfo nest env (ISearch fc depth) Nothing
     = do est <- get EST
          nmty <- genName "searchTy"
-         ty <- metaVar fc Rig0 env nmty (TType fc)
+         ty <- metaVar fc erased env nmty (TType fc)
          nm <- genName "search"
          sval <- searchVar fc rig depth (Resolved (defining est)) env nm ty
          pure (sval, gnf env ty)
@@ -207,7 +207,7 @@ checkTerm rig elabinfo nest env (Implicit fc b) (Just gexpty)
          pure (metaval, gexpty)
 checkTerm rig elabinfo nest env (Implicit fc b) Nothing
     = do nmty <- genName "implicit_type"
-         ty <- metaVar fc Rig0 env nmty (TType fc)
+         ty <- metaVar fc erased env nmty (TType fc)
          nm <- genName "_"
          metaval <- metaVar fc rig env nm ty
          -- Add to 'bindIfUnsolved' if 'b' set

--- a/src/TTImp/Elab/Utils.idr
+++ b/src/TTImp/Elab/Utils.idr
@@ -34,13 +34,13 @@ findErasedFrom defs pos (NBind fc x (Pi c _ aty) scf)
     = do -- In the scope, use 'Erased fc True' to mean 'argument is erased'.
          -- It's handy here, because we can use it to tell if a detaggable
          -- argument position is available
-         sc <- scf defs (toClosure defaultOpts [] (Erased fc (c == Rig0)))
+         sc <- scf defs (toClosure defaultOpts [] (Erased fc (isErased c)))
          (erest, dtrest) <- findErasedFrom defs (1 + pos) sc
          let dt' = if !(detagSafe defs aty)
                       then (pos :: dtrest) else dtrest
-         case c of
-              Rig0 => pure (pos :: erest, dt')
-              _ => pure (erest, dt')
+         pure $ if isErased c
+                   then (pos :: erest, dt')
+                   else (erest, dt')
 findErasedFrom defs pos tm = pure ([], [])
 
 -- Find the argument positions in the given type which are guaranteed to be

--- a/src/TTImp/Interactive/CaseSplit.idr
+++ b/src/TTImp/Interactive/CaseSplit.idr
@@ -300,7 +300,7 @@ mkCase {c} {u} fn orig lhs_raw
                -- be an erased name in a case block (which will be bound elsewhere
                -- once split and turned into a pattern)
                (lhs, _) <- elabTerm {c} {m} {u}
-                                    fn (InLHS Rig0) [] (MkNested [])
+                                    fn (InLHS erased) [] (MkNested [])
                                     [] (IBindHere (getFC lhs_raw) PATTERN lhs_raw)
                                     Nothing
                put Ctxt defs -- reset the context, we don't want any updates

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -472,7 +472,7 @@ dropLinearErrors : {auto c : Ref Ctxt Defs} ->
 dropLinearErrors fc [] = pure []
 dropLinearErrors fc (t :: ts)
     = tryUnify
-          (do linearCheck fc Rig1 False [] t
+          (do linearCheck fc linear False [] t
               ts' <- dropLinearErrors fc ts
               pure (t :: ts'))
           (dropLinearErrors fc ts)

--- a/src/TTImp/Interactive/GenerateDef.idr
+++ b/src/TTImp/Interactive/GenerateDef.idr
@@ -54,7 +54,7 @@ expandClause : {auto c : Ref Ctxt Defs} ->
 expandClause loc n c
     = do log 10 $ "Trying clause " ++ show c
          c <- uniqueRHS c
-         Right clause <- checkClause Rig1 False n [] (MkNested []) [] c
+         Right clause <- checkClause linear False n [] (MkNested []) [] c
             | Left _ => pure [] -- TODO: impossible clause, do something
                                 -- appropriate
          let MkClause {vars} env lhs rhs = clause
@@ -142,7 +142,7 @@ generateSplits loc fn (ImpossibleClause fc lhs) = pure []
 generateSplits loc fn (WithClause fc lhs wval cs) = pure []
 generateSplits {c} {m} {u} loc fn (PatClause fc lhs rhs)
     = do (lhstm, _) <-
-                elabTerm fn (InLHS Rig1) [] (MkNested []) []
+                elabTerm fn (InLHS linear) [] (MkNested []) []
                          (IBindHere loc PATTERN lhs) Nothing
          traverse (trySplit fc lhs lhstm rhs) (splittableNames lhs)
 

--- a/src/TTImp/Interactive/MakeLemma.idr
+++ b/src/TTImp/Interactive/MakeLemma.idr
@@ -13,8 +13,7 @@ import TTImp.Utils
 %default covering
 
 used : RigCount -> Bool
-used Rig0 = False
-used _ = True
+used = not . isErased
 
 hiddenName : Name -> Bool
 hiddenName (MN "_" _) = True
@@ -46,11 +45,11 @@ getArgs {vars} env (S k) (Bind _ x (Pi c p ty) sc)
          let x' = UN !(uniqueName defs (map nameRoot vars) (nameRoot x))
          (sc', ty) <- getArgs (Pi c p ty :: env) k (renameTop x' sc)
          -- Don't need to use the name if it's not used in the scope type
-         let mn = case c of
-                       RigW => case shrinkTerm sc (DropCons SubRefl) of
+         let mn = if c == top
+                       then case shrinkTerm sc (DropCons SubRefl) of
                                     Nothing => Just x'
                                     _ => Nothing
-                       _ => Just x'
+                       else Just x'
          let p' = if used c && not (bindableArg 0 sc) && not (hiddenName x)
                      then Explicit
                      else Implicit

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -75,7 +75,7 @@ totalityOpt
          pure CoveringOnly
 
 fnOpt : Rule FnOpt
-fnOpt = do x <- totalityOpt          
+fnOpt = do x <- totalityOpt
            pure $ Totality x
 
 fnDirectOpt : Rule FnOpt
@@ -200,9 +200,9 @@ mutual
     <|> pure Nothing
 
   getMult : Maybe Integer -> EmptyRule RigCount
-  getMult (Just 0) = pure Rig0
-  getMult (Just 1) = pure Rig1
-  getMult Nothing = pure RigW
+  getMult (Just 0) = pure erased
+  getMult (Just 1) = pure linear
+  getMult Nothing = pure top
   getMult _ = fatalError "Invalid multiplicity (must be 0 or 1)"
 
   pibindAll : FC -> PiInfo RawImp -> List (RigCount, Maybe Name, RawImp) ->
@@ -273,7 +273,7 @@ mutual
            ns <- sepBy1 (symbol ",") unqualifiedName
            nend <- location
            let nfc = MkFC fname nstart nend
-           let binders = map (\n => (Rig0, Just (UN n), Implicit nfc False)) ns
+           let binders = map (\n => (erased, Just (UN n), Implicit nfc False)) ns
            symbol "."
            scope <- typeExpr fname indents
            end <- location
@@ -452,7 +452,7 @@ mutual
       mkPi : FilePos -> FilePos -> RawImp -> List (PiInfo RawImp, RawImp) -> RawImp
       mkPi start end arg [] = arg
       mkPi start end arg ((exp, a) :: as)
-            = IPi (MkFC fname start end) RigW exp Nothing arg
+            = IPi (MkFC fname start end) top exp Nothing arg
                   (mkPi start end a as)
 
   export
@@ -568,7 +568,7 @@ recordParam fname indents
          commit
          start <- location
          info <- the (EmptyRule (PiInfo RawImp))
-                 (pure  AutoImplicit <* keyword "auto" 
+                 (pure  AutoImplicit <* keyword "auto"
               <|>(do
                   keyword "default"
                   t <- simpleExpr fname indents
@@ -580,7 +580,7 @@ recordParam fname indents
   <|> do start <- location
          n <- name
          end <- location
-         pure [(n, RigW, Explicit, Implicit (MkFC fname start end) False)]
+         pure [(n, top, Explicit, Implicit (MkFC fname start end) False)]
 
 fieldDecl : FileName -> IndentInfo -> Rule (List IField)
 fieldDecl fname indents
@@ -602,7 +602,7 @@ fieldDecl fname indents
              ty <- expr fname indents
              end <- location
              pure (map (\n => MkIField (MkFC fname start end)
-                                       Rig1 p (UN n) ty) ns)
+                                       linear p (UN n) ty) ns)
 
 recordDecl : FileName -> IndentInfo -> Rule ImpDecl
 recordDecl fname indents
@@ -670,7 +670,7 @@ topDecl fname indents
          let opts = mapMaybe getRight visOpts
          claim <- tyDecl fname indents
          end <- location
-         pure (IClaim (MkFC fname start end) RigW vis opts claim)
+         pure (IClaim (MkFC fname start end) top vis opts claim)
   <|> recordDecl fname indents
   <|> do symbol "%"; commit
          directive fname indents

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -106,7 +106,7 @@ mkSpecDef {vars} fc env gdef pename sargs fn stk
          -- Add as RigW - if it's something else, we don't need it at
          -- runtime anyway so this is wasted effort, therefore a failure
          -- is okay!
-         peidx <- addDef pename (newDef fc pename RigW [] sty Public None)
+         peidx <- addDef pename (newDef fc pename top [] sty Public None)
          addToSave (Resolved peidx)
 
          let PMDef pminfo pmargs ct tr pats = definition gdef

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -220,7 +220,7 @@ getRelevantArg defs i (Just _) world (NBind _ _ (Pi _ _ _) sc) -- more than one 
 getRelevantArg defs i rel world tm
     = pure (maybe Nothing (\r => Just (world, r)) rel)
 
--- If there's one constructor with only one non-Rig0 argument, flag it as
+-- If there's one constructor with only one non-erased argument, flag it as
 -- a newtype for optimisation
 export
 findNewtype : {auto c : Ref Ctxt Defs} ->
@@ -331,6 +331,7 @@ processData {vars} eopts nest env fc vis (MkImpData dfc n_in ty_raw opts cons_ra
 
          let ddef = MkData (MkCon dfc n arity fullty) cons
          addData vars vis tidx ddef
+         findNewtype cons
 
          -- Type is defined mutually with every data type undefined at the
          -- point it was declared, and every data type undefined right now

--- a/src/TTImp/ProcessParams.idr
+++ b/src/TTImp/ProcessParams.idr
@@ -36,7 +36,7 @@ processParams {vars} {c} {m} {u} nest env fc ps ds
          -- then read off the environment from the elaborated type. This way
          -- we'll get all the implicit names we need
          let pty_raw = mkParamTy ps
-         pty_imp <- bindTypeNames [] vars (IBindHere fc (PI Rig0) pty_raw)
+         pty_imp <- bindTypeNames [] vars (IBindHere fc (PI erased) pty_raw)
          log 10 $ "Checking " ++ show pty_imp
          pty <- checkTerm (-1) InType []
                           nest env pty_imp (gType fc)
@@ -54,7 +54,7 @@ processParams {vars} {c} {m} {u} nest env fc ps ds
     mkParamTy : List (Name, RawImp) -> RawImp
     mkParamTy [] = IType fc
     mkParamTy ((n, ty) :: ps)
-       = IPi fc RigW Explicit (Just n) ty (mkParamTy ps)
+       = IPi fc top Explicit (Just n) ty (mkParamTy ps)
 
     applyEnv : Env Term vs -> Name ->
                Core (Name, (Maybe Name, List Name, FC -> NameType -> Term vs))

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -150,7 +150,7 @@ processType {vars} eopts nest env fc rig vis opts (MkImpTy tfc n_in ty_raw)
          ty <-
              wrapError (InType fc n) $
                    checkTerm idx InType (HolesOkay :: eopts) nest env
-                             (IBindHere fc (PI Rig0) ty_raw)
+                             (IBindHere fc (PI erased) ty_raw)
                              (gType fc)
          logTermNF 3 ("Type of " ++ show n) [] (abstractEnvType tfc env ty)
          -- TODO: Check name visibility

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -218,7 +218,7 @@ mutual
   unelabBinder umode fc env x (Pi rig p ty) sctm sc scty
       = do (ty', _) <- unelabTy umode env ty
            p' <- unelabPi umode env p
-           let nm = if used 0 sctm || rig /= RigW || isDefImp p
+           let nm = if used 0 sctm || rig /= top || isDefImp p
                        then Just x else Nothing
            pure (IPi fc rig p' nm ty' sc, gType fc)
     where

--- a/src/Yaffle/REPL.idr
+++ b/src/Yaffle/REPL.idr
@@ -66,7 +66,7 @@ process (ProofSearch n_in)
          [(n, i, ty)] <- lookupTyName n_in (gamma defs)
               | [] => throw (UndefinedName toplevelFC n_in)
               | ns => throw (AmbiguousName toplevelFC (map fst ns))
-         def <- search toplevelFC RigW False 1000 n ty []
+         def <- search toplevelFC top False 1000 n ty []
          defs <- get Ctxt
          defnf <- normaliseHoles defs [] def
          coreLift (printLn !(toFullNames defnf))


### PR DESCRIPTION
Hi, I have this branch on which I've been working in order to experiment with different semi rings for tracking linearity. It remove the access to the RigCount constructor and replace with interfaces and functions such as

```
-- check for linear
isRig1 : (Semiring a, Eq a) => a -> Bool

-- eliminator for semirings
elimSemi : (Semiring a, Eq a) => b -> b -> (a -> b) -> a -> b 

-- create the value for neutral addition which stands for "erased"
ring0 : (Semiring a) => a
```

Should this be merged onto master or should I keep running my own branch until I have more substantial results?