### PR TITLE
Add Text.{Lexer,Parser}.Core to the list of installed modules

### DIFF
--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -8,4 +8,6 @@ modules = Syntax.WithProof,
           Text.Quantity,
           Control.Delayed,
           Text.Parser,
-          Text.Lexer
+          Text.Lexer,
+          Text.Parser.Core,
+          Text.Lexer.Core


### PR DESCRIPTION
Otherwise these files do not get installed, which leads to missing-module errors on new installations and stale library modules on existing installations.