### PR TITLE
Make the applicative combinators in `Text.Parser.Core` lazier

### DIFF
--- a/libs/contrib/Text/Parser/Core.idr
+++ b/libs/contrib/Text/Parser/Core.idr
@@ -86,16 +86,17 @@ export
 export
 (<*>) : {c1, c2 : _} ->
         Grammar tok c1 (a -> b) ->
-        Lazy (Grammar tok c2 a) ->
+        Inf (Grammar tok c2 a) ->
         Grammar tok (c1 || c2) b
-(<*>) x y = SeqEmpty x (\f => map f (Force y))
+(<*>) {c1 = False} x y = SeqEmpty x (\f => map f y)
+(<*>) {c1 = True } x y = SeqEmpty x (\f => map f (Force y))
 
 ||| Sequence two grammars. If both succeed, use the value of the first one.
 ||| Guaranteed to consume if either grammar consumes.
 export
 (<*) : {c1, c2 : _} ->
        Grammar tok c1 a ->
-       Lazy (Grammar tok c2 b) ->
+       Inf (Grammar tok c2 b) ->
        Grammar tok (c1 || c2) a
 (<*) x y = map const x <*> y
 
@@ -104,7 +105,7 @@ export
 export
 (*>) : {c1, c2 : _} ->
        Grammar tok c1 a ->
-       Lazy (Grammar tok c2 b) ->
+       Inf (Grammar tok c2 b) ->
        Grammar tok (c1 || c2) b
 (*>) x y = map (const id) x <*> y
 

--- a/libs/contrib/Text/Parser/Core.idr
+++ b/libs/contrib/Text/Parser/Core.idr
@@ -86,16 +86,16 @@ export
 export
 (<*>) : {c1, c2 : _} ->
         Grammar tok c1 (a -> b) ->
-        Grammar tok c2 a ->
+        Lazy (Grammar tok c2 a) ->
         Grammar tok (c1 || c2) b
-(<*>) x y = SeqEmpty x (\f => map f y)
+(<*>) x y = SeqEmpty x (\f => map f (Force y))
 
 ||| Sequence two grammars. If both succeed, use the value of the first one.
 ||| Guaranteed to consume if either grammar consumes.
 export
 (<*) : {c1, c2 : _} ->
        Grammar tok c1 a ->
-       Grammar tok c2 b ->
+       Lazy (Grammar tok c2 b) ->
        Grammar tok (c1 || c2) a
 (<*) x y = map const x <*> y
 
@@ -104,7 +104,7 @@ export
 export
 (*>) : {c1, c2 : _} ->
        Grammar tok c1 a ->
-       Grammar tok c2 b ->
+       Lazy (Grammar tok c2 b) ->
        Grammar tok (c1 || c2) b
 (*>) x y = map (const id) x <*> y
 


### PR DESCRIPTION
In a situation with mutually recursive rules built entirely using `<|>`, `<*>`, `<*` and `*>`, the resulting parser loops infinitely while allocating all the memory. This is because `<*>` is strict despite its underlying implementation not always using the RHS. The resulting situation is similar to wrapping `if` in a strict function.

This patch makes `<*>` and friends take `Inf`-lazy right-hand sides to match the design of the parser.

Strictly speaking, the RHS needs to be only `inf c1`-lazy because if the LHS does not consume, then the RHS is guaranteed to be used. However, this would complicate user code, which, whenever being `c1`-polymorphic, would have to always case-split based on `c1` so that the compiler can insert `Delay`s automatically. This patch sacrifices a bit of efficiency and makes it always lazy.