### PR TITLE
Fix build on macOS

### DIFF
--- a/dist/rts/idris_rts.c
+++ b/dist/rts/idris_rts.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <errno.h>
+#include <time.h>
 
 #include "idris_rts.h"
 #include "idris_gc.h"


### PR DESCRIPTION
As suggested by @edwinb in #218, adding `#include <time.h>` does fix the build on macOS!

Hopefully the CI will confirm that it still works on Linux.