### PR TITLE
Add version and file to TTCError

### DIFF
--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -13,8 +13,7 @@ import System
 
 public export
 data TTCErrorMsg
-    = FormatOlder
-    | FormatNewer
+    = Format String Int Int
     | EndOfBuffer String
     | Corrupt String
 
@@ -107,8 +106,9 @@ data Error
 
 export
 Show TTCErrorMsg where
-  show FormatOlder = "TTC data is in an older format"
-  show FormatNewer = "TTC data is in a newer format"
+  show (Format file ver exp) =
+    let age = if ver < exp then "older" else "newer" in
+        "TTC data is in an " ++ age ++ " format, file: " ++ file ++ ", expected version: " ++ show exp ++ ", actual version: " ++ show ver
   show (EndOfBuffer when) = "End of buffer when reading " ++ when
   show (Corrupt ty) = "Corrupt TTC data for " ++ ty
 

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -203,7 +203,7 @@ TTC TTMFile where
       = do hdr <- fromBuf b
            when (hdr /= "TTM") $ corrupt "TTM header"
            ver <- fromBuf b
-           checkTTCVersion ver ttcVersion
+           checkTTCVersion "" ver ttcVersion -- maybe change the interface to get the filename
            md <- fromBuf b
            pure (MkTTMFile ver md)
 


### PR DESCRIPTION
I had some issues while playing with TTC files and couldn't tell which version from which file wasn't matching. So I've added this debug info to the `Format` constructor