### PR TITLE
Add basic help to REPL

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1577,8 +1577,8 @@ parserCommandsForHelp : CommandTable
 parserCommandsForHelp =
   [ exprArgCmd (ParseREPLCmd ["t", "type"]) Check "Check the type of an expression"
   , nameArgCmd (ParseREPLCmd ["printdef"]) PrintDef "Show the definition of a function"
-  , nameArgCmd (ParseREPLCmd ["s", "search"]) ProofSearch "???"
-  , nameArgCmd (ParseIdentCmd "di") DebugInfo "???"
+  , nameArgCmd (ParseREPLCmd ["s", "search"]) ProofSearch "Search for values by type"
+  , nameArgCmd (ParseIdentCmd "di") DebugInfo "Show debugging information for a name"
   , noArgCmd (ParseREPLCmd ["q", "quit", "exit"]) Quit "Exit the Idris system"
   , noArgCmd (ParseREPLCmd ["cwd"]) CWD "Displays the current working directory"
   , exprArgCmd (ParseIdentCmd "exec") Exec "Compile to an executable and run"

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1576,19 +1576,19 @@ exprArgCmd parseCmd command doc = (names, ExprArg, doc, parse)
 parserCommandsForHelp : CommandTable
 parserCommandsForHelp =
   [ exprArgCmd (ParseREPLCmd ["t", "type"]) Check "Check the type of an expression"
-  , exprArgCmd (ParseIdentCmd "exec") Exec "Compile to an executable and run"
   , nameArgCmd (ParseREPLCmd ["printdef"]) PrintDef "Show the definition of a function"
   , nameArgCmd (ParseREPLCmd ["s", "search"]) ProofSearch "???"
   , nameArgCmd (ParseIdentCmd "di") DebugInfo "???"
-  , nameArgCmd (ParseREPLCmd ["miss", "missing"]) Missing "Show missing clauses"
-  , nameArgCmd (ParseKeywordCmd "total") Total "Check the totality of a name"
-  , noArgCmd (ParseREPLCmd ["h", "help"]) Help "Display this help text"
   , noArgCmd (ParseREPLCmd ["q", "quit", "exit"]) Quit "Exit the Idris system"
   , noArgCmd (ParseREPLCmd ["cwd"]) CWD "Displays the current working directory"
-  , noArgCmd (ParseREPLCmd ["version"]) ShowVersion "Display the Idris version"
+  , exprArgCmd (ParseIdentCmd "exec") Exec "Compile to an executable and run"
   , noArgCmd (ParseREPLCmd ["r", "reload"]) Reload "Reload current file"
   , noArgCmd (ParseREPLCmd ["e", "edit"]) Edit "Edit current file using $EDITOR or $VISUAL"
+  , nameArgCmd (ParseREPLCmd ["miss", "missing"]) Missing "Show missing clauses"
+  , nameArgCmd (ParseKeywordCmd "total") Total "Check the totality of a name"
   , noArgCmd (ParseREPLCmd ["m", "metavars"]) Metavars "Show remaining proof obligations (metavariables or holes)"
+  , noArgCmd (ParseREPLCmd ["version"]) ShowVersion "Display the Idris version"
+  , noArgCmd (ParseREPLCmd ["h", "help"]) Help "Display this help text"
   ]
 
 export

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1556,6 +1556,7 @@ exprArgCmd names command doc = (names, ExprArg, doc, parse)
 parserCommandsForHelp : CommandTable
 parserCommandsForHelp =
   [ exprArgCmd ["t", "type"] Check "Check the type of an expression"
+  , exprArgCmd ["exec"] Exec "Compile to an executable and run"
   , nameArgCmd ["printdef"] PrintDef "Show the definition of a function"
   , nameArgCmd ["s", "search"] ProofSearch "???"
   , nameArgCmd ["di"] DebugInfo "???"
@@ -1591,9 +1592,6 @@ undocumentedNonEmptyCommand
          n <- unqualifiedName
          tm <- expr pdef "(interactive)" init
          pure (Compile tm n)
-  <|> do symbol ":"; exactIdent "exec"
-         tm <- expr pdef "(interactive)" init
-         pure (Exec tm)
   <|> do symbol ":"; replCmd ["log", "logging"]
          i <- intLit
          pure (SetLog (fromInteger i))

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1533,6 +1533,8 @@ nonEmptyCommand
   <|> do symbol ":"; exactIdent "exec"
          tm <- expr pdef "(interactive)" init
          pure (Exec tm)
+  <|> do symbol ":"; replCmd ["?", "h", "help"]
+         pure Help
   <|> do symbol ":"; replCmd ["r", "reload"]
          pure Reload
   <|> do symbol ":"; replCmd ["e", "edit"]

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -832,13 +832,18 @@ mutual
                                    showSep ", " (map show xs)
   displayResult  (LogLevelSet k) = printResult $ "Set loglevel to " ++ show k
   displayResult  (VersionIs x) = printResult $ showVersion True x
-  displayResult  (RequestedHelp) = printResult $ "This is where the help will go"
+  displayResult  (RequestedHelp) = printResult displayHelp
   displayResult  (Edited (DisplayEdit [])) = pure ()
   displayResult  (Edited (DisplayEdit xs)) = printResult $ showSep "\n" xs
   displayResult  (Edited (EditError x)) = printError x
   displayResult  (Edited (MadeLemma name pty pappstr)) = printResult (show name ++ " : " ++ show pty ++ "\n" ++ pappstr)
   displayResult  (OptionsSet opts) = printResult $ showSep "\n" $ map show opts
   displayResult  _ = pure ()
+
+  displayHelp : String
+  displayHelp =
+    showSep "\n" $ map cmdInfo help
+    where cmdInfo (cmds, args, text) = "   " ++ showSep " " cmds ++ " " ++ show args ++ " " ++ text
 
   export
   displayErrors : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -456,6 +456,7 @@ data REPLResult : Type where
   Done : REPLResult
   REPLError : String -> REPLResult
   Executed : PTerm -> REPLResult
+  RequestedHelp : REPLResult
   Evaluated : PTerm -> (Maybe PTerm) -> REPLResult
   Printed : List String -> REPLResult
   TermChecked : PTerm -> PTerm -> REPLResult
@@ -620,6 +621,8 @@ process (Compile ctm outfile)
     = compileExp ctm outfile
 process (Exec ctm)
     = execExp ctm
+process Help
+    = pure RequestedHelp
 process (ProofSearch n_in)
     = do defs <- get Ctxt
          [(n, i, ty)] <- lookupTyName n_in (gamma defs)
@@ -829,6 +832,7 @@ mutual
                                    showSep ", " (map show xs)
   displayResult  (LogLevelSet k) = printResult $ "Set loglevel to " ++ show k
   displayResult  (VersionIs x) = printResult $ showVersion True x
+  displayResult  (RequestedHelp) = printResult $ "This is where the help will go"
   displayResult  (Edited (DisplayEdit [])) = pure ()
   displayResult  (Edited (DisplayEdit xs)) = printResult $ showSep "\n" xs
   displayResult  (Edited (EditError x)) = printError x

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -843,7 +843,17 @@ mutual
   displayHelp : String
   displayHelp =
     showSep "\n" $ map cmdInfo help
-    where cmdInfo (cmds, args, text) = "   " ++ showSep " " cmds ++ " " ++ show args ++ " " ++ text
+    where
+      makeSpace : Nat -> String
+      makeSpace n = pack $ take n (repeat ' ')
+
+      col : Nat -> Nat -> String -> String -> String -> String
+      col c1 c2 l m r =
+        l ++ (makeSpace $ c1 `minus` length l) ++
+        m ++ (makeSpace $ c2 `minus` length m) ++ r
+
+      cmdInfo : (List String, CmdArg, String) -> String
+      cmdInfo (cmds, args, text) = "   " ++ col 16 12 (showSep " " cmds) (show args) text
 
   export
   displayErrors : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -304,6 +304,7 @@ data REPLCmd : Type where
      Edit : REPLCmd
      Compile : PTerm -> String -> REPLCmd
      Exec : PTerm -> REPLCmd
+     Help : REPLCmd
      ProofSearch : Name -> REPLCmd
      DebugInfo : Name -> REPLCmd
      SetOpt : REPLOpt -> REPLCmd


### PR DESCRIPTION
:wave:

This PR adds basic help to the REPL.

I based much of the implementation off of the help system for the Idris 1 REPL, with some tweaks here and there to account for things that work in Haskell but not in Idris.

The majority of the commands have been ported, but I'm still working on some of the more advanced ones. Where possible, I took the help descriptions from the Idris 1 REPL, but 1) I'm not sure if those are all entirely accurate, and 2) there are some commands in Idris 2 not present in Idris 1. I'll probably need some help documenting those.

This is my first time working with Idris, so any feedback on areas that could be improved would be very welcome :slightly_smiling_face: