### PR TITLE
Make Text.Lexer.Core.concatMap split on consumption flag

### DIFF
--- a/libs/contrib/Text/Lexer/Core.idr
+++ b/libs/contrib/Text/Lexer/Core.idr
@@ -79,8 +79,8 @@ export
 concatMap : {c : Bool} -> (a -> Recognise c) -> (xs : List a) -> 
             Recognise (c && (isCons xs))
 concatMap {c} _ [] = rewrite andFalseFalse c in Empty
-concatMap {c = True} f (x :: xs) = SeqEat (f x) (Core.concatMap f xs)
-concatMap {c = False} f (x :: xs) = SeqEmpty (f x) (Core.concatMap f xs)
+concatMap {c = True} f (x :: xs) = f x `SeqEat` Core.concatMap f xs
+concatMap {c = False} f (x :: xs) = f x `SeqEmpty` Core.concatMap f xs
 
 data StrLen : Type where
      MkStrLen : String -> Nat -> StrLen

--- a/libs/contrib/Text/Lexer/Core.idr
+++ b/libs/contrib/Text/Lexer/Core.idr
@@ -76,13 +76,11 @@ reject = Lookahead False
 ||| of a list. The resulting recogniser will consume input if the produced
 ||| recognisers consume and the list is non-empty.
 export
-concatMap : (a -> Recognise c) -> (xs : List a) -> 
+concatMap : {c : Bool} -> (a -> Recognise c) -> (xs : List a) -> 
             Recognise (c && (isCons xs))
 concatMap {c} _ [] = rewrite andFalseFalse c in Empty
-concatMap {c} f (x :: xs) 
-   = rewrite andTrueNeutral c in
-     rewrite sym (orSameAndRightNeutral c (isCons xs)) in
-             SeqEmpty (f x) (Core.concatMap f xs)
+concatMap {c = True} f (x :: xs) = SeqEat (f x) (Core.concatMap f xs)
+concatMap {c = False} f (x :: xs) = SeqEmpty (f x) (Core.concatMap f xs)
 
 data StrLen : Type where
      MkStrLen : String -> Nat -> StrLen


### PR DESCRIPTION
[My tokeniser](https://github.com/ziman/itt-idris/blob/idris2/ITT/Parser.idr#L130) uses `exact "->"` for the arrow token; (most of) the rest is defined using other lexing combinators. I get this behaviour:
```idris
ITT.Parser> lex "x -> y z"
Right [MkToken 0 0 (Ident "x")]
```
It turns out `exact` is defined using [`concatMap`](https://github.com/edwinb/Idris2/blob/master/libs/contrib/Text/Lexer/Core.idr#L79), which does a lot of rewriting. Out of ideas, I changed this function to do what all other lexing/parsing combinators do: case-split on the consumption flag to use the right sequencing combinator. That somehow happens to fix the problem.
```idris
ITT.Parser> lex "x -> y z"
Right [MkToken 0 0 (Ident "x"), MkToken 0 2 Arrow, MkToken 0 5 (Ident "y"), MkToken 0 7 (Ident "z")]
```
I can't say I understand why exactly this fixes my problem but perhaps someone else does?