### PR TITLE
Fix SeqEmpty in Text.Lexer.Core.

### DIFF
--- a/libs/contrib/Text/Lexer/Core.idr
+++ b/libs/contrib/Text/Lexer/Core.idr
@@ -137,7 +137,7 @@ scan (SeqEat r1 r2) tok str
          assert_total (scan r2 tok' rest)
 scan (SeqEmpty r1 r2) tok str
     = do (tok', rest) <- scan r1 tok str
-         scan r2 tok' str
+         scan r2 tok' rest
 scan (Alt r1 r2) tok str
     = maybe (scan r2 tok str) Just (scan r1 tok str)
 


### PR DESCRIPTION
A short while ago, I opened (and then closed) https://github.com/edwinb/Idris2/pull/241.

The reason that the "fix" worked was that it avoided the use of `SeqEmpty`, which was broken because it did not advance in the string. A classic typo.

This PR fixes it.