### PR TITLE
Make `List.sortBy` stable

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -387,9 +387,9 @@ sortBy cmp xs  = let (x, y) = split xs in
           (sortBy cmp (assert_smaller xs x))
           (sortBy cmp (assert_smaller xs y)) -- not structurally smaller, hence assert
   where
-    splitRec : List a -> List a -> (List a -> List a) -> (List a, List a)
-    splitRec (_::_::xs) (y::ys) zs = splitRec xs ys (zs . ((::) y))
-    splitRec _          ys      zs = (zs [], ys)
+    splitRec : List b -> List a -> (List a -> List a) -> (List a, List a)
+    splitRec (_::_::xs) (y::ys) zs = splitRec xs ys ((y ::) . zs)
+    splitRec  _             ys  zs = (ys, zs [])
 
     split : List a -> (List a, List a)
     split xs = splitRec xs xs id

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -392,9 +392,10 @@ sortBy cmp xs  = let (x, y) = split xs in
     splitRec : List b -> List a -> (List a -> List a) -> (List a, List a)
     splitRec (_::_::xs) (y::ys) zs = splitRec xs ys (zs . ((::) y))
     splitRec _          ys      zs = (ys, zs [])
-    -- In the above base-case clause, we put `ys` first to get a stable sort.
+    -- In the above base-case clause, we put `ys` on the LHS to get a stable sort.
     -- This is because `mergeBy` prefers taking elements from its RHS operand
-    -- if both heads are equal.
+    -- if both heads are equal, and all elements in `zs []` precede all elements of `ys`
+    -- in the original list.
 
     split : List a -> (List a, List a)
     split xs = splitRec xs xs id


### PR DESCRIPTION
The current version of `List.sortBy` does not preserve the order of equal elements.
```idris
xs = [(4, 'c'), (1, 'z'), (1, 'x'), (3, 'b'), (1,'a'), (1,'m'), (1,'k'), (2, 'a')]

> sortBy (\x, y => fst x `compare` fst y) $ sortBy (\x, y => snd x `compare` snd y) xs
[(1, 'z'), (1, 'x'), (1, 'm'), (1, 'k'), (1, 'a'), (2, 'a'), (3, 'b'), (4, 'c')]
```

This patch makes it stable:
```
> sortBy (\x, y => fst x `compare` fst y) $ sortBy (\x, y => snd x `compare` snd y) xs
[(1, 'a'), (1, 'm'), (1, 'k'), (1, 'x'), (1, 'z'), (2, 'a'), (3, 'b'), (4, 'c')]
```