### PR TITLE
Fix runtime error in `the Int (cast "")`

### DIFF
--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -19,8 +19,10 @@
     (if (number? x) x 0)))
 (define destroy-prefix
   (lambda (x)
-    (if (eqv? x "") ""
-      (if (eqv? (string-ref x 0) #\#) "" x))))
+    (cond
+      ((equal? x "") "")
+      ((equal? (string-ref x 0) #\#) "")
+      (else x))))
 (define cast-string-int
   (lambda (x)
     (floor (cast-num (string->number (destroy-prefix x))))))

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -19,7 +19,8 @@
     (if (number? x) x 0)))
 (define destroy-prefix
   (lambda (x)
-    (if (eqv? (string-ref x 0) #\#) "" x)))
+    (if (eqv? x "") ""
+      (if (eqv? (string-ref x 0) #\#) "" x))))
 (define cast-string-int
   (lambda (x)
     (floor (cast-num (string->number (destroy-prefix x))))))

--- a/support/chicken/support.scm
+++ b/support/chicken/support.scm
@@ -19,8 +19,10 @@
     (if (number? x) x 0)))
 (define destroy-prefix
   (lambda (x)
-    (if (eqv? x "") ""
-      (if (eqv? (string-ref x 0) #\#) "" x))))
+    (cond
+      ((equal? x "") "")
+      ((equal? (string-ref x 0) #\#) "")
+      (else x))))
 (define cast-string-int
   (lambda (x)
     (floor (cast-num (string->number (destroy-prefix x))))))

--- a/support/chicken/support.scm
+++ b/support/chicken/support.scm
@@ -19,7 +19,8 @@
     (if (number? x) x 0)))
 (define destroy-prefix
   (lambda (x)
-    (if (eqv? (string-ref x 0) #\#) "" x)))
+    (if (eqv? x "") ""
+      (if (eqv? (string-ref x 0) #\#) "" x))))
 (define cast-string-int
   (lambda (x)
     (floor (cast-num (string->number (destroy-prefix x))))))

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -19,8 +19,10 @@
     (if (number? x) x 0)))
 (define destroy-prefix
   (lambda (x)
-    (if (eqv? x "") ""
-      (if (eqv? (string-ref x 0) #\#) "" x))))
+    (cond
+      ((equal? x "") "")
+      ((equal? (string-ref x 0) #\#) "")
+      (else x))))
 (define cast-string-int
   (lambda (x)
     (floor (cast-num (string->number (destroy-prefix x))))))

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -19,7 +19,8 @@
     (if (number? x) x 0)))
 (define destroy-prefix
   (lambda (x)
-    (if (eqv? (string-ref x 0) #\#) "" x)))
+    (if (eqv? x "") ""
+      (if (eqv? (string-ref x 0) #\#) "" x))))
 (define cast-string-int
   (lambda (x)
     (floor (cast-num (string->number (destroy-prefix x))))))


### PR DESCRIPTION
With the following program, Idris errors out.
```idris
$ cat x.idr
main : IO ()
main = printLn (the Int (cast ""))
```
```
$ idris2 x.idr -x main
Exception in string-ref: 0 is not a valid index for ""
```

It turns out that the RTS always attempts to look at first character of the string, even if the string is empty.

This patch fixes it:
```
$ idris2 x.idr -x main
0
```