### PR TITLE
Enhance literate mode to recognise multi-modes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Compiler updates:
   are translated to just that argument, to save repeated packing and unpacking.
   (c.f. `newtype` in Haskell)
 
+* Extend Idris2's literate mode to support reading Markdown and OrgMode files.
+  For more details see: https://idris2.readthedocs.io/en/latest/reference/literate.html
+
 Changes since Idris 1
 ---------------------
 

--- a/docs/reference/literate.rst
+++ b/docs/reference/literate.rst
@@ -1,0 +1,55 @@
+.. _ref-sect-literate:
+
+**********************
+Literate Programming
+**********************
+
+Idris2 supports several types of literate mode styles.
+
+The unlit'n has been designed based such that we assume that we are parsing markdown-like languages
+The unlit'n is performed by a Lexer that uses a provided literate style to recognise code blocks and code lines.
+Anything else is ignored.
+
+A literate style consists of:
+
++ a list of String encoded code block deliminators;
++ a list of line indicators; and
++ a list of valid file extensions.
+
+Lexing is simple and greedy in that when consuming anything that is a code blocks we treat everything as code until we reach the closing deliminator.
+This means that use of verbatim modes in a literate file will also be treated as active code.
+
+In future we should add support for literate ``LaTeX`` files, and potentially other common document formats.
+But more importantly, a more intelligent processing of literate documents using a pandoc like library in Idris such as: `Edda <https://github.com/jfdm/edda>` would also be welcome.
+
+Bird Style Literate Files
+=========================
+
+Bird notation is a classic literate mode found in Haskell, (and Orwell) in which code lines begin with ``>``.
+Other lines are treated as documentation.
+
+We treat files with an extension of ``.lidr`` as bird style literate files.
+
+Embedding in Markdown-like documents
+====================================
+
+While Bird Style literate mode is useful, it does not lend itself well
+to more modern markdown-like notations such as Org-Mode and CommonMark.
+
+Idris2 also provides support for recognising both 'visible' and 'invisible' code blocks and lines in both CommonMark and OrgMode documents.
+
+OrgMode
+*******
+
++ Org mode source blocks for idris are recognised as visible code blocks,
++ Comment blocks that begin with ``#+COMMENT: idris`` are treated as invisible code blocks.
++ Invisible code lines are denoted with ``#+IDRIS:``.
+
+We treat files with an extension of ``.org`` as org-mode style literate files.
+
+CommonMark
+************
+
+Only code blocks denoted by standard code blocks labelled as idris are recognised.
+
+We treat files with an extension of ``.md`` and ``.markdown`` as org-mode style literate files.

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -18,3 +18,4 @@ This is a placeholder, to get set up with readthedocs.
 
    packages
    envvars
+   literate

--- a/idris2.ipkg
+++ b/idris2.ipkg
@@ -79,6 +79,7 @@ modules =
 
     Text.Lexer,
     Text.Lexer.Core,
+    Text.Literate,
     Text.Parser,
     Text.Parser.Core,
     Text.Quantity,

--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -83,7 +83,7 @@ nsToSource loc ns
          let fnameOrig = showSep dirSep (reverse ns)
          let fnameBase = maybe fnameOrig (\srcdir => srcdir ++ dirSep ++ fnameOrig) (source_dir d)
          let fs = map (\ext => fnameBase ++ ext)
-                      [".idr", ".lidr", ".yaff"]
+                      [".idr", ".lidr", ".yaff", ".org", ".md"]
          Just f <- firstAvailable fs
             | Nothing => throw (ModuleNotFound loc ns)
          pure f
@@ -192,7 +192,7 @@ getEntries d
              | Left err => pure []
          ds <- assert_total $ getEntries d
          pure (f :: ds)
-  
+
 dirEntries : String -> IO (Either FileError (List String))
 dirEntries dir
     = do Right d <- dirOpen dir
@@ -200,7 +200,7 @@ dirEntries dir
          ds <- getEntries d
          dirClose d
          pure (Right ds)
-  
+
 findIpkg : List String -> Maybe String
 findIpkg [] = Nothing
 findIpkg (f :: fs)

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -176,10 +176,10 @@ getClause l n
          argns <- getEnvArgNames defs envlen !(nf defs [] ty)
          Just srcLine <- getSourceLine l
            | Nothing => pure Nothing
-         let (lit, src) = isLit srcLine
-         pure (Just (indent lit loc ++ fnName True n ++ concat (map (" " ++) argns) ++
+         let (mark, src) = isLitLine srcLine
+         pure (Just (indent mark loc ++ fnName True n ++ concat (map (" " ++) argns) ++
                   " = ?" ++ fnName False n ++ "_rhs"))
   where
-    indent : Bool -> FC -> String
-    indent True fc = ">" ++ pack (replicate (cast (max 0 (snd (startPos fc) - 1))) ' ')
-    indent False fc = pack (replicate (cast (snd (startPos fc))) ' ')
+    indent : Maybe String -> FC -> String
+    indent (Just mark) fc = relit (Just mark) $ pack (replicate (cast (max 0 (snd (startPos fc) - 1))) ' ')
+    indent Nothing fc = pack (replicate (cast (snd (startPos fc))) ' ')

--- a/src/Idris/IDEMode/MakeClause.idr
+++ b/src/Idris/IDEMode/MakeClause.idr
@@ -16,15 +16,15 @@ showRHSName n
 export
 makeWith : Name -> String -> String
 makeWith n srcline
-    = let (lit, src) = isLit srcline
+    = let (markerM, src) = isLitLine srcline
           isrc : (Nat, String) =
              case span isSpace src of
                   (spc, rest) => (length spc, rest)
           indent = fst isrc
           src = snd isrc
           lhs = pack (readLHS 0 (unpack src)) in
-          mkWithArg lit indent lhs ++ "\n" ++
-          mkWithPat lit indent lhs ++ "\n"
+          mkWithArg markerM indent lhs ++ "\n" ++
+          mkWithPat markerM indent lhs ++ "\n"
   where
     readLHS : (brackets : Nat) -> List Char -> List Char
     readLHS Z ('=' :: rest) = []
@@ -35,17 +35,14 @@ makeWith n srcline
     readLHS n (x :: rest) = x :: readLHS n rest
     readLHS n [] = []
 
-    pref : Bool -> Nat -> String
-    pref l ind
-        = (if l then ">" else "") ++
-          pack (replicate ind ' ')
+    pref : Maybe String -> Nat -> String
+    pref mark ind = relit mark $ pack (replicate ind ' ')
 
-    mkWithArg : Bool -> Nat -> String -> String
-    mkWithArg lit indent lhs
-        = pref lit indent ++ lhs ++ "with (_)"
+    mkWithArg : Maybe String -> Nat -> String -> String
+    mkWithArg mark indent lhs
+        = pref mark indent ++ lhs ++ "with (_)"
 
-    mkWithPat : Bool -> Nat -> String -> String
-    mkWithPat lit indent lhs
-        = pref lit (indent + 2) ++ lhs ++ "| with_pat = ?" ++
+    mkWithPat : Maybe String -> Nat -> String -> String
+    mkWithPat mark indent lhs
+        = pref mark (indent + 2) ++ lhs ++ "| with_pat = ?" ++
               showRHSName n ++ "_rhs"
-

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -258,7 +258,8 @@ displayIDEResult outf i  (VersionIs x) = printIDEResult outf i versionSExp
 
 displayIDEResult outf i  (Edited (DisplayEdit xs)) = printIDEResult outf i $ StringAtom $ showSep "\n" xs
 displayIDEResult outf i  (Edited (EditError x)) = printIDEError outf i x
-displayIDEResult outf i  (Edited (MadeLemma lit name pty pappstr)) = printIDEResult outf i $ StringAtom $ (if lit then "> " else "") ++ show name ++ " : " ++ show pty ++ "\n" ++ pappstr
+displayIDEResult outf i  (Edited (MadeLemma lit name pty pappstr)) =
+  printIDEResult outf i $ StringAtom $ (relit lit $ show name ++ " : " ++ show pty ++ "\n") ++ pappstr
 displayIDEResult outf i  _ = pure ()
 
 

--- a/src/Parser/Support.idr
+++ b/src/Parser/Support.idr
@@ -22,7 +22,7 @@ public export
 data ParseError = ParseFail String (Maybe (Int, Int)) (List Token)
                 | LexFail (Int, Int, String)
                 | FileFail FileError
-                | LitFail (List Int)
+                | LitFail LiterateError
 
 export
 Show ParseError where
@@ -33,8 +33,8 @@ Show ParseError where
       = "Lex error at " ++ show (c, l) ++ " input: " ++ str
   show (FileFail err)
       = "File error: " ++ show err
-  show (LitFail l)
-      = "Lit error(s) at " ++ show l
+  show (LitFail (MkLitErr l c str))
+      = "Lit error(s) at " ++ show (c, l) ++ " input: " ++ str
 
 export
 eoi : EmptyRule ()
@@ -47,10 +47,10 @@ eoi
     isEOI _ = False
 
 export
-runParserTo : Bool -> Bool -> (TokenData Token -> Bool) ->
+runParserTo : Maybe LiterateStyle -> (TokenData Token -> Bool) ->
               String -> Grammar (TokenData Token) e ty -> Either ParseError ty
-runParserTo lit enforce pred str p
-    = case unlit lit enforce str of
+runParserTo lit pred str p
+    = case unlit lit str of
            Left l => Left $ LitFail l
            Right str =>
              case lexTo pred str of
@@ -65,15 +65,15 @@ runParserTo lit enforce pred str p
                        Right (val, _) => Right val
 
 export
-runParser : Bool -> Bool -> String -> Grammar (TokenData Token) e ty -> Either ParseError ty
-runParser lit enforce = runParserTo lit enforce (const False)
+runParser : Maybe LiterateStyle -> String -> Grammar (TokenData Token) e ty -> Either ParseError ty
+runParser lit = runParserTo lit (const False)
 
 export
 parseFile : (fn : String) -> Rule ty -> IO (Either ParseError ty)
 parseFile fn p
     = do Right str <- readFile fn
              | Left err => pure (Left (FileFail err))
-         pure (runParser (isLitFile fn) True str p)
+         pure (runParser (isLitFile fn) str p)
 
 
 -- Some basic parsers used by all the intermediate forms
@@ -590,5 +590,3 @@ nonEmptyBlock item
          res <- blockEntry (AtPos col) item
          ps <- blockEntries (snd res) item
          pure (fst res :: ps)
-
-

--- a/src/Text/Literate.idr
+++ b/src/Text/Literate.idr
@@ -101,7 +101,7 @@ record LiterateError where
 ||| + Bird Style
 |||
 |||```
-|||MkLitStyle Nil [">", "<"] [".lidr"]
+|||MkLitStyle Nil [">"] [".lidr"]
 |||```
 |||
 ||| + Literate Haskell (for LaTeX)
@@ -109,7 +109,7 @@ record LiterateError where
 |||```
 |||MkLitStyle [("\\begin{code}", "\\end{code}"),("\\begin{spec}","\\end{spec}")]
 |||           Nil
-|||           ["lhs", "tex"]
+|||           [".lhs", ".tex"]
 |||```
 |||
 ||| + OrgMode
@@ -117,7 +117,7 @@ record LiterateError where
 |||```
 |||MkLitStyle [("#+BEGIN_SRC idris","#+END_SRC"), ("#+COMMENT idris","#+END_COMMENT")]
 |||           ["#+IDRIS:"]
-|||           ["org"]
+|||           [".org"]
 |||```
 |||
 ||| + Common Mark
@@ -125,7 +125,7 @@ record LiterateError where
 |||```
 |||MkLitStyle [("```idris","```"), ("<!-- idris","--!>")]
 |||           Nil
-|||           [".md", ".idris.md"]
+|||           [".md", ".markdown"]
 |||```
 |||
 public export

--- a/src/Text/Literate.idr
+++ b/src/Text/Literate.idr
@@ -1,0 +1,211 @@
+||| A simple module to process 'literate' documents.
+|||
+||| The module uses a lexer to split the document into code blocks,
+||| delineated by user-defined markers, and code lines that are
+||| indicated be a line marker. The lexer returns a document stripped
+||| of non-code elements but preserving the original document's line
+||| count. Column numbering of code lines are not preserved.
+|||
+||| The underlying tokeniser is greedy.
+|||
+||| Once it identifies a line marker it reads a prettifying space then
+||| consumes until the end of line. Once identifies a starting code
+||| block marker, the lexer will consume input until the next
+||| identifiable end block is encountered. Any other content is
+||| treated as part of the original document.
+|||
+||| Thus, the input literate files *must* be well-formed w.r.t
+||| to code line markers and code blocks.
+|||
+||| A further restriction is that literate documents cannot contain
+||| the markers within the document's main text: This will confuse the
+||| lexer.
+|||
+module Text.Literate
+
+import Text.Lexer
+
+import Data.List.Views
+
+%default total
+
+untilEOL : Recognise False
+untilEOL = manyUntil (is '\n') any
+
+line : String -> Lexer
+line s = exact s <+> space <+> untilEOL
+
+block : String -> String -> Lexer
+block s e = surround (exact s <+> untilEOL) (exact e <+> untilEOL) any
+
+data Token = CodeBlock String String String
+           | Any String
+           | CodeLine String String
+
+Show Token where
+  showPrec d (CodeBlock l r x) = showCon d "CodeBlock" $ showArg l ++ showArg r ++ showArg x
+  showPrec d (Any x)           = showCon d "Any" $ showArg x
+  showPrec d (CodeLine m x)    = showCon d "CodeLine" $ showArg m ++ showArg x
+
+rawTokens : (delims  : List (String, String))
+         -> (markers : List String)
+         -> TokenMap (Token)
+rawTokens delims ls =
+          map (\(l,r) => (block l r, CodeBlock (trim l) (trim r))) delims
+       ++ map (\m => (line m, CodeLine (trim m))) ls
+       ++ [(any, Any)]
+
+||| Merge the tokens into a single source file.
+reduce : List (TokenData Token) -> String -> String
+reduce [] acc = acc
+reduce (MkToken _ _ (Any x) :: rest) acc = reduce rest (acc ++ blank_content)
+  where
+    -- Preserve the original document's line count.
+    blank_content : String
+    blank_content = if elem '\n' (unpack x)
+      then concat $ replicate (length (lines x)) "\n"
+      else ""
+reduce (MkToken _ _ (CodeLine m src) :: rest) acc =
+    reduce rest (acc ++ (substr
+                           (length m + 1) -- remove space to right of marker.
+                           (length src)
+                           src))
+
+reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc with (lines src) -- Strip the deliminators surrounding the block.
+  reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | [] = reduce rest acc -- 1
+  reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | (s :: ys) with (snocList ys)
+    reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | (s :: []) | Empty = reduce rest acc -- 2
+    reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | (s :: (srcs ++ [f])) | (Snoc rec) =
+        reduce rest (acc ++ "\n" ++ unlines srcs)
+
+-- [ NOTE ] 1 & 2 shouldn't happen as code blocks are well formed i.e. have two deliminators.
+
+
+public export
+record LiterateError where
+  constructor MkLitErr
+  line   : Int
+  column : Int
+  input  : String
+
+||| Description of literate styles.
+|||
+||| A 'literate' style comprises of
+|||
+||| + a list of code block deliminators (`deliminators`);
+||| + a list of code line markers (`line_markers`); and
+||| + a list of known file extensions `file_extensions`.
+|||
+||| Some example specifications:
+|||
+||| + Bird Style
+|||
+|||```
+|||MkLitStyle Nil [">", "<"] [".lidr"]
+|||```
+|||
+||| + Literate Haskell (for LaTeX)
+|||
+|||```
+|||MkLitStyle [("\\begin{code}", "\\end{code}"),("\\begin{spec}","\\end{spec}")]
+|||           Nil
+|||           ["lhs", "tex"]
+|||```
+|||
+||| + OrgMode
+|||
+|||```
+|||MkLitStyle [("#+BEGIN_SRC idris","#+END_SRC"), ("#+COMMENT idris","#+END_COMMENT")]
+|||           ["#+IDRIS:"]
+|||           ["org"]
+|||```
+|||
+||| + Common Mark
+|||
+|||```
+|||MkLitStyle [("```idris","```"), ("<!-- idris","--!>")]
+|||           Nil
+|||           [".md", ".idris.md"]
+|||```
+|||
+public export
+record LiterateStyle where
+  constructor MkLitStyle
+  ||| The pairs of start and end tags for code blocks.
+  deliminators : List (String, String)
+
+  ||| Line markers that indicate a line contains code.
+  line_markers : List String
+
+  ||| Recognised file extensions. Not used by the module, but will be
+  ||| of use when connecting to code that reads in the original source
+  ||| files.
+  file_extensions : List String
+
+||| Given a 'literate specification' extract the code from the
+||| literate source file (`litStr`) that follows the presented style.
+|||
+||| @specification The literate specification to use.
+||| @litStr  The literate source file.
+|||
+||| Returns a `LiterateError` if the literate file contains malformed
+||| code blocks or code lines.
+|||
+export
+extractCode : (specification : LiterateStyle)
+           -> (litStr        : String)
+           -> Either LiterateError String
+extractCode (MkLitStyle delims markers exts) str =
+      case lex (rawTokens delims markers) str of
+        (toks, (_,_,"")) => Right $ reduce toks ""
+        (_, (l,c,i))     => Left (MkLitErr l c i)
+
+||| Synonym for `extractCode`.
+export
+unlit : (specification : LiterateStyle)
+     -> (litStr        : String)
+     -> Either LiterateError String
+unlit = extractCode
+
+||| Is the provided line marked up using a line marker?
+|||
+||| If the line is suffixed by any one of the style's set of line
+||| markers then return length of literate line marker, and the code stripped from the line
+||| marker. Otherwise, return Nothing and the unmarked line.
+export
+isLiterateLine : (specification : LiterateStyle)
+              -> (str : String)
+              -> Pair (Maybe String) String
+isLiterateLine (MkLitStyle delims markers _) str with (lex (rawTokens delims markers) str)
+  isLiterateLine (MkLitStyle delims markers _) str | ([MkToken _ _ (CodeLine m str')], (_,_, "")) = (Just m, str')
+  isLiterateLine (MkLitStyle delims markers _) str | (_, _) = (Nothing, str)
+
+||| Given a 'literate specification' embed the given code using the
+||| literate style provided.
+|||
+||| If the style uses deliminators to denote code blocks use the first
+||| pair of deliminators in the style. Otherwise use first linemarker
+||| in the style. If there is **no style** return the presented code
+||| string unembedded.
+|||
+|||
+||| @specification The literate specification to use.
+||| @code  The code to embed,
+|||
+|||
+export
+embedCode : (specification : LiterateStyle)
+         -> (code : String)
+         -> String
+embedCode (MkLitStyle ((s,e)::delims) _            _) str = unlines [s,str,e]
+embedCode (MkLitStyle Nil             (m::markers) _) str = unwords [m, str]
+embedCode (MkLitStyle _               _            _) str = str
+
+||| Synonm for `embedCode`
+export
+relit : (specification : LiterateStyle)
+     -> (code : String)
+     -> String
+relit = embedCode
+
+-- --------------------------------------------------------------------- [ EOF ]

--- a/src/Yaffle/REPL.idr
+++ b/src/Yaffle/REPL.idr
@@ -151,12 +151,10 @@ repl : {auto c : Ref Ctxt Defs} ->
 repl
     = do coreLift (putStr "Yaffle> ")
          inp <- coreLift getLine
-         case runParser False False inp command of
+         case runParser Nothing inp command of
               Left err => do coreLift (printLn err)
                              repl
               Right cmd =>
                   do if !(processCatch cmd)
                         then repl
                         else pure ()
-
-

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -50,7 +50,7 @@ idrisTests
        -- Literate
        "literate001", "literate002", "literate003", "literate004",
        "literate005", "literate006", "literate007", "literate008",
-       "literate009",
+       "literate009", "literate010", "literate011", "literate012",
        -- Interfaces
        "interface001", "interface002", "interface003", "interface004",
        "interface005", "interface006", "interface007", "interface008",

--- a/tests/idris2/literate001/IEdit.lidr
+++ b/tests/idris2/literate001/IEdit.lidr
@@ -16,4 +16,3 @@
 
 > suc' : x = y -> S x = S y
 > suc' {x} {y} prf = ?quuz
-

--- a/tests/idris2/literate007/IEdit.lidr
+++ b/tests/idris2/literate007/IEdit.lidr
@@ -8,4 +8,3 @@
 > dupAll xs = zipHere xs xs
 >   where
 >     zipHere : forall n . Vect n a -> Vect n b -> Vect n (a, b)
-

--- a/tests/idris2/literate007/IEdit.org
+++ b/tests/idris2/literate007/IEdit.org
@@ -1,0 +1,12 @@
+#+begin_src idris
+data Vect : Nat -> Type -> Type where
+     Nil : Vect Z a
+     (::) : a -> Vect k a -> Vect (S k) a
+#+end_src
+
+#+IDRIS: %name Vect xs, ys, zs
+
+#+IDRIS: dupAll : Vect n a -> Vect n (a, a)
+#+IDRIS: dupAll xs = zipHere xs xs
+#+IDRIS:   where
+#+IDRIS:     zipHere : forall n . Vect n a -> Vect n b -> Vect n (a, b)

--- a/tests/idris2/literate007/IEditOrg.org
+++ b/tests/idris2/literate007/IEditOrg.org
@@ -1,0 +1,12 @@
+#+begin_src idris
+data Vect : Nat -> Type -> Type where
+     Nil : Vect Z a
+     (::) : a -> Vect k a -> Vect (S k) a
+#+end_src
+
+#+IDRIS: %name Vect xs, ys, zs
+
+#+IDRIS: dupAll : Vect n a -> Vect n (a, a)
+#+IDRIS: dupAll xs = zipHere xs xs
+#+IDRIS:   where
+#+IDRIS:     zipHere : forall n . Vect n a -> Vect n b -> Vect n (a, b)

--- a/tests/idris2/literate007/expected
+++ b/tests/idris2/literate007/expected
@@ -2,3 +2,7 @@
 Main> >     zipHere [] ys = []
 >     zipHere (x :: xs) (y :: ys) = (x, y) :: zipHere xs ys
 Main> Bye for now!
+1/1: Building IEditOrg (IEditOrg.org)
+Main> #+IDRIS:     zipHere [] ys = []
+#+IDRIS:     zipHere (x :: xs) (y :: ys) = (x, y) :: zipHere xs ys
+Main> Bye for now!

--- a/tests/idris2/literate007/input2
+++ b/tests/idris2/literate007/input2
@@ -1,0 +1,2 @@
+:gd 12 zipHere
+:q

--- a/tests/idris2/literate007/run
+++ b/tests/idris2/literate007/run
@@ -1,3 +1,4 @@
 $1 --no-banner IEdit.lidr < input
+$1 --no-banner IEditOrg.org < input2
 
 rm -rf build

--- a/tests/idris2/literate010/MyFirstIdrisProgram.org
+++ b/tests/idris2/literate010/MyFirstIdrisProgram.org
@@ -1,0 +1,44 @@
+#+TITLE: My First Idris2 Program
+
+This is a literate Idris2 Org-Mode file that the Idris2 understands.
+
+We can have visibile code blocks using source blocks in idris.
+
+#+BEGIN_SRC idris
+data Natural = Zero | Succ Natural
+#+END_SRC
+
+#+BEGIN_SRC idris
+data Vect : Natural -> Type -> Type where
+  Empty : Vect Zero a
+  Cons  : a -> Vect k a -> Vect (Succ k) a
+#+END_SRC
+
+We can have hidden literate lines that Idris will understand.
+
+#+IDRIS: %name Vect xs, ys
+
+However, we Idris2' literate support is greedy and does not understand all of the supported literate modes comments and verbatim blocks.
+
+Thus:
+
+#+begin_example
+
+#+IDRIS: plus : Natural -> Natural -> Natural
+
+#+end_example
+
+is also an active code line.
+
+We can also abuse org-mode comments to hide code not required for publication.
+
+#+begin_comment idris
+
+cannotSeeThis : Natural -> Natural
+
+#+end_comment
+
+#+BEGIN_SRC idris
+main : IO ()
+main = putStrLn "Hello!"
+#+END_SRC

--- a/tests/idris2/literate010/expected
+++ b/tests/idris2/literate010/expected
@@ -1,0 +1,1 @@
+1/1: Building MyFirstIdrisProgram (MyFirstIdrisProgram.org)

--- a/tests/idris2/literate010/run
+++ b/tests/idris2/literate010/run
@@ -1,0 +1,3 @@
+$1 --check --no-banner MyFirstIdrisProgram.org
+
+rm -rf build

--- a/tests/idris2/literate011/IEdit.md
+++ b/tests/idris2/literate011/IEdit.md
@@ -1,0 +1,16 @@
+```idris
+data Vect : Nat -> Type -> Type where
+     Nil : Vect Z a
+     (::) : a -> Vect k a -> Vect (S k) a
+```
+
+```idris
+%name Vect xs, ys, zs
+```
+
+```idris
+dupAll : Vect n a -> Vect n (a, a)
+dupAll xs = zipHere xs xs
+  where
+    zipHere : forall n . Vect n a -> Vect n b -> Vect n (a, b)
+```

--- a/tests/idris2/literate011/expected
+++ b/tests/idris2/literate011/expected
@@ -1,0 +1,4 @@
+1/1: Building IEdit (IEdit.md)
+Main>     zipHere [] ys = []
+    zipHere (x :: xs) (y :: ys) = (x, y) :: zipHere xs ys
+Main> Bye for now!

--- a/tests/idris2/literate011/input
+++ b/tests/idris2/literate011/input
@@ -1,0 +1,2 @@
+:gd 15 zipHere
+:q

--- a/tests/idris2/literate011/run
+++ b/tests/idris2/literate011/run
@@ -1,0 +1,3 @@
+$1 --no-banner IEdit.md < input
+
+rm -rf build

--- a/tests/idris2/literate012/IEdit.org
+++ b/tests/idris2/literate012/IEdit.org
@@ -1,0 +1,30 @@
+#+TITLE: Interactive Editing Working
+
+#+begin_src idris
+data Vect : Nat -> Type -> Type where
+     Nil : Vect Z a
+     (::) : a -> Vect k a -> Vect (S k) a
+#+end_src
+
+#+IDRIS: %name Vect xs, ys, zs
+
+#+begin_src idris
+append : Vect n a -> Vect m a -> Vect (n + m) a
+append {n} xs ys = ?foo
+#+end_src
+
+#+begin_src idris
+vadd : Num a => Vect n a -> Vect n a -> Vect n a
+vadd [] ys = ?bar
+vadd (x :: xs) ys = ?baz
+#+end_src
+
+#+begin_src idris
+suc : (x : Nat) -> (y : Nat) -> x = y -> S x = S y
+suc x y prf = ?quux
+#+end_src
+
+#+begin_src idris
+suc' : x = y -> S x = S y
+suc' {x} {y} prf = ?quuz
+#+end_src

--- a/tests/idris2/literate012/IEdit2.org
+++ b/tests/idris2/literate012/IEdit2.org
@@ -1,0 +1,31 @@
+#+TITLE: Interactive Editing Working
+
+#+begin_src idris
+data Vect : Nat -> Type -> Type where
+     Nil : Vect Z a
+     (::) : a -> Vect k a -> Vect (S k) a
+#+end_src
+
+#+IDRIS: %name Vect xs, ys, zs
+
+#+begin_src idris
+append : Vect n a -> Vect m a -> Vect (n + m) a
+append {n = Z} [] ys = ?foo_1
+append {n = (S k)} (x :: xs) ys = ?foo_2
+#+end_src
+
+#+begin_src idris
+vadd : Num a => Vect n a -> Vect n a -> Vect n a
+vadd [] [] = ?bar_1
+vadd (x :: xs) (y :: ys) = ?baz_1
+#+end_src
+
+#+begin_src idris
+suc : (x : Nat) -> (y : Nat) -> x = y -> S x = S y
+suc x x Refl = ?quux_1
+#+end_src
+
+#+begin_src idris
+suc' : x = y -> S x = S y
+suc' {x = y} {y = y} Refl = ?quuz_1
+#+end_src

--- a/tests/idris2/literate012/expected
+++ b/tests/idris2/literate012/expected
@@ -1,5 +1,5 @@
 1/1: Building IEdit (IEdit.org)
-Main> append {n = Z} [] ys = ?foo_1
+Main> append {n = 0} [] ys = ?foo_1
 append {n = (S k)} (x :: xs) ys = ?foo_2
 Main> vadd [] [] = ?bar_1
 Main> vadd (x :: xs) (y :: ys) = ?baz_1

--- a/tests/idris2/literate012/expected
+++ b/tests/idris2/literate012/expected
@@ -1,0 +1,8 @@
+1/1: Building IEdit (IEdit.org)
+Main> append {n = Z} [] ys = ?foo_1
+append {n = (S k)} (x :: xs) ys = ?foo_2
+Main> vadd [] [] = ?bar_1
+Main> vadd (x :: xs) (y :: ys) = ?baz_1
+Main> suc x x Refl = ?quux_1
+Main> suc' {x = y} {y = y} Refl = ?quuz_1
+Main> Bye for now!

--- a/tests/idris2/literate012/input
+++ b/tests/idris2/literate012/input
@@ -1,0 +1,6 @@
+:cs 13 11 xs
+:cs 18 8 ys
+:cs 19 15 ys
+:cs 24 8 prf
+:cs 29 13 prf
+:q

--- a/tests/idris2/literate012/run
+++ b/tests/idris2/literate012/run
@@ -1,0 +1,3 @@
+$1 --no-banner IEdit.org < input
+
+rm -rf build


### PR DESCRIPTION
While Bird Style literate mode is useful, it does not lend itself well
to more modern markdown-like notations such as Org-Mode and CommonMark.

This commit extends Idris2's existing literate mode to recognise both
'visible' and 'invisible' code blocks and lines in predefined markdown
styles.

The styles and their elements are:

+ Bird Style :: `>` denotes a visible code line, `<` a hidden code
                line.

+ OrgMode :: Org Mode source blocks for idris are recognised as
             visible code blocks, and comment blocks are invisible
             code blocks. Invisible code lines are denoted with
             `#+IDRIS:`.

+ CommonMark :: Only code blocks denoted by standard code blocks
                labelled as idris are recognised.

For backwards compatibility, we recognise literate modes by file
extension:

+ Bird Style :: `.lidr`
+ OrgMode :: `.org`
+ CommonMark :: `.md`

In future we should add support for literate `LaTeX` files, and more
intelligent processing of literate documents using a pandoc like
library in Idris such as: [Edda](https://github.com/jfdm/edda).