### PR TITLE
Don't clobber CWD in `--exec`

### DIFF
--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -21,10 +21,10 @@ public export
 record Codegen where
   constructor MkCG
   ||| Compile an Idris 2 expression, saving it to a file.
-  compileExpr : Ref Ctxt Defs ->
+  compileExpr : Ref Ctxt Defs -> (execDir : String) ->
                 ClosedTerm -> (outfile : String) -> Core (Maybe String)
   ||| Execute an Idris 2 expression directly.
-  executeExpr : Ref Ctxt Defs -> ClosedTerm -> Core ()
+  executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
 
 ||| compile
 ||| Given a value of type Codegen, produce a standalone function
@@ -35,12 +35,8 @@ compile : {auto c : Ref Ctxt Defs} ->
           ClosedTerm -> (outfile : String) -> Core (Maybe String)
 compile {c} cg tm out
     = do makeExecDirectory
-         cwd <- coreLift $ currentDir
          d <- getDirs
-         coreLift $ changeDir (exec_dir d)
-         fn <- compileExpr cg c tm out
-         coreLift $ changeDir cwd
-         pure fn
+         compileExpr cg c (exec_dir d) tm out
 
 ||| execute
 ||| As with `compile`, produce a functon that executes
@@ -50,11 +46,8 @@ execute : {auto c : Ref Ctxt Defs} ->
           Codegen -> ClosedTerm -> Core ()
 execute {c} cg tm
     = do makeExecDirectory
-         cwd <- coreLift $ currentDir
          d <- getDirs
-         coreLift $ changeDir (exec_dir d)
-         executeExpr cg c tm
-         coreLift $ changeDir cwd
+         executeExpr cg c (exec_dir d) tm
          pure ()
 
 -- ||| Recursively get all calls in a function definition

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -353,16 +353,15 @@ compileToSS c tm outfile
 compileToSO : {auto c : Ref Ctxt Defs} ->
               (appDirRel : String) -> (outSsAbs : String) -> Core ()
 compileToSO appDirRel outSsAbs
-    = do tmpfn <- coreLift tmpName
-         let tmpFileRel = appDirRel ++ dirSep ++ tmpfn
+    = do tmpFileAbs <- coreLift tmpName
          chez <- coreLift $ findChez
          let build= "#!" ++ chez ++ " --script\n" ++
                     "(parameterize ([optimize-level 3]) (compile-program \"" ++
                     outSsAbs ++ "\"))"
-         Right () <- coreLift $ writeFile tmpFileRel build
-            | Left err => throw (FileErr tmpFileRel err)
-         coreLift $ chmod tmpFileRel 0o755
-         coreLift $ system tmpFileRel
+         Right () <- coreLift $ writeFile tmpFileAbs build
+            | Left err => throw (FileErr tmpFileAbs err)
+         coreLift $ chmod tmpFileAbs 0o755
+         coreLift $ system tmpFileAbs
          pure ()
 
 makeSh : String -> String -> Core ()

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -315,11 +315,13 @@ getFgnCall n
                              throw (InternalError ("No compiled definition for " ++ show n))
                           Just d => schFgnDef (location def) n d
 
-startChez : String -> String -> String
-startChez target ext
-    = "#!/bin/sh\n\n" ++
-      "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`dirname $0`/" ++ target ++ "_app\n" ++
-      "`dirname $0`/" ++ target ++ "_app/" ++ target ++ "." ++ ext ++ " $*\n"
+startChez : String -> String
+startChez target = unlines
+    [ "#!/bin/sh"
+    , ""
+    , "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`dirname " ++ target ++ "`"
+    , target ++ " \"$@\""
+    ]
 
 ||| Compile a TT expression to Chez Scheme
 compileToSS : Ref Ctxt Defs ->
@@ -349,46 +351,49 @@ compileToSS c tm outfile
 
 ||| Compile a Chez Scheme source file to an executable, daringly with runtime checks off.
 compileToSO : {auto c : Ref Ctxt Defs} ->
-              (ssFile : String) -> Core ()
-compileToSO ssFile
-    = do tmpFile <- coreLift $ tmpName
+              (appDirRel : String) -> (outSsAbs : String) -> Core ()
+compileToSO appDirRel outSsAbs
+    = do tmpfn <- coreLift tmpName
+         let tmpFileRel = appDirRel ++ dirSep ++ tmpfn
          chez <- coreLift $ findChez
          let build= "#!" ++ chez ++ " --script\n" ++
                     "(parameterize ([optimize-level 3]) (compile-program \"" ++
-                    ssFile ++ "\"))"
-         Right () <- coreLift $ writeFile tmpFile build
-            | Left err => throw (FileErr tmpFile err)
-         coreLift $ chmod tmpFile 0o755
-         coreLift $ system tmpFile
+                    outSsAbs ++ "\"))"
+         Right () <- coreLift $ writeFile tmpFileRel build
+            | Left err => throw (FileErr tmpFileRel err)
+         coreLift $ chmod tmpFileRel 0o755
+         coreLift $ system tmpFileRel
          pure ()
 
 makeSh : String -> String -> Core ()
-makeSh outfile ext
-    = do Right () <- coreLift $ writeFile outfile (startChez outfile ext)
-            | Left err => throw (FileErr outfile err)
+makeSh outShRel outAbs
+    = do Right () <- coreLift $ writeFile outShRel (startChez outAbs)
+            | Left err => throw (FileErr outShRel err)
          pure ()
 
 ||| Chez Scheme implementation of the `compileExpr` interface.
-compileExpr : Bool -> Ref Ctxt Defs ->
+compileExpr : Bool -> Ref Ctxt Defs -> (execDir : String) ->
               ClosedTerm -> (outfile : String) -> Core (Maybe String)
-compileExpr makeitso c tm outfile
-    = do coreLift $ mkdirs [outfile ++ "_app"]
-         coreLift $ changeDir (outfile ++ "_app")
-         let outSs = outfile ++ ".ss"
-         compileToSS c tm outSs
-         logTime "Make SO" $ when makeitso $ compileToSO outSs
-         coreLift $ changeDir ".."
-         makeSh outfile (if makeitso then "so" else "ss")
-         coreLift $ chmod outfile 0o755
-         pure (Just outfile)
+compileExpr makeitso c execDir tm outfile
+    = do let appDirRel = execDir ++ dirSep ++ outfile ++ "_app"
+         coreLift $ mkdirs (splitDir appDirRel)
+         cwd <- coreLift currentDir
+         let outSsAbs = cwd ++ dirSep ++ appDirRel ++ dirSep ++ outfile ++ ".ss"
+         let outSoAbs = cwd ++ dirSep ++ appDirRel ++ dirSep ++ outfile ++ ".so"
+         compileToSS c tm outSsAbs
+         logTime "Make SO" $ when makeitso $ compileToSO appDirRel outSsAbs
+         let outShRel = execDir ++ dirSep ++ outfile
+         makeSh outShRel (if makeitso then outSoAbs else outSsAbs)
+         coreLift $ chmod outShRel 0o755
+         pure (Just outShRel)
 
 ||| Chez Scheme implementation of the `executeExpr` interface.
 ||| This implementation simply runs the usual compiler, saving it to a temp file, then interpreting it.
-executeExpr : Ref Ctxt Defs -> ClosedTerm -> Core ()
-executeExpr c tm
-    = do compileExpr False c tm "_tmpchez"
-         cwd <- coreLift $ currentDir
-         coreLift $ system (cwd ++ dirSep ++ "_tmpchez")
+executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
+executeExpr c execDir tm
+    = do Just sh <- compileExpr False c execDir tm "_tmpchez"
+            | Nothing => throw (InternalError "compileExpr returned Nothing")
+         coreLift $ system sh
          pure ()
 
 ||| Codegen wrapper for Chez scheme implementation.

--- a/src/Compiler/Scheme/Chicken.idr
+++ b/src/Compiler/Scheme/Chicken.idr
@@ -84,11 +84,11 @@ compileToSCM c tm outfile
          coreLift $ chmod outfile 0o755
          pure ()
 
-compileExpr : Ref Ctxt Defs ->
+compileExpr : Ref Ctxt Defs -> (execDir : String) ->
               ClosedTerm -> (outfile : String) -> Core (Maybe String)
-compileExpr c tm outfile
+compileExpr c execDir tm outfile
     = do tmp <- coreLift $ tmpName
-         let outn = tmp ++ ".scm"
+         let outn = execDir ++ dirSep ++ tmp ++ ".scm"
          compileToSCM c tm outn
          csc <- coreLift findCSC
          ok <- coreLift $ system (csc ++ " " ++ outn ++ " -o " ++ outfile)
@@ -96,10 +96,10 @@ compileExpr c tm outfile
             then pure (Just outfile)
             else pure Nothing
 
-executeExpr : Ref Ctxt Defs -> ClosedTerm -> Core ()
-executeExpr c tm
+executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
+executeExpr c execDir tm
     = do tmp <- coreLift $ tmpName
-         let outn = tmp ++ ".scm"
+         let outn = execDir ++ dirSep ++ tmp ++ ".scm"
          compileToSCM c tm outn
          csi <- coreLift findCSI
          coreLift $ system (csi ++ " -s " ++ outn)

--- a/src/Compiler/Scheme/Chicken.idr
+++ b/src/Compiler/Scheme/Chicken.idr
@@ -88,7 +88,7 @@ compileExpr : Ref Ctxt Defs -> (execDir : String) ->
               ClosedTerm -> (outfile : String) -> Core (Maybe String)
 compileExpr c execDir tm outfile
     = do tmp <- coreLift $ tmpName
-         let outn = execDir ++ dirSep ++ tmp ++ ".scm"
+         let outn = tmp ++ ".scm"
          compileToSCM c tm outn
          csc <- coreLift findCSC
          ok <- coreLift $ system (csc ++ " " ++ outn ++ " -o " ++ outfile)
@@ -99,7 +99,7 @@ compileExpr c execDir tm outfile
 executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
 executeExpr c execDir tm
     = do tmp <- coreLift $ tmpName
-         let outn = execDir ++ dirSep ++ tmp ++ ".scm"
+         let outn = tmp ++ ".scm"
          compileToSCM c tm outn
          csi <- coreLift findCSI
          coreLift $ system (csi ++ " -s " ++ outn)

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -325,7 +325,7 @@ compileExpr c execDir tm outfile
 executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
 executeExpr c execDir tm
     = do tmp <- coreLift $ tmpName
-         let outn = execDir ++ dirSep ++ tmp ++ ".rkt"
+         let outn = tmp ++ ".rkt"
          compileToRKT c tm outn
          racket <- coreLift findRacket
          coreLift $ system (racket ++ " " ++ outn)

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -5,6 +5,7 @@ import Compiler.CompileExpr
 import Compiler.Inline
 import Compiler.Scheme.Common
 
+import Core.Options
 import Core.Context
 import Core.Directory
 import Core.Name
@@ -309,21 +310,22 @@ compileToRKT c tm outfile
          coreLift $ chmod outfile 0o755
          pure ()
 
-compileExpr : Ref Ctxt Defs ->
+compileExpr : Ref Ctxt Defs -> (execDir : String) ->
               ClosedTerm -> (outfile : String) -> Core (Maybe String)
-compileExpr c tm outfile
-    = do let outn = outfile ++ ".rkt"
-         compileToRKT c tm outn
+compileExpr c execDir tm outfile
+    = do let outSs = execDir ++ dirSep ++ outfile ++ ".rkt"
+         let outBin = execDir ++ dirSep ++ outfile
+         compileToRKT c tm outSs
          raco <- coreLift findRacoExe
-         ok <- coreLift $ system (raco ++ " -o " ++ outfile ++ " " ++ outn)
+         ok <- coreLift $ system (raco ++ " -o " ++ outBin ++ " " ++ outSs)
          if ok == 0
             then pure (Just outfile)
             else pure Nothing
 
-executeExpr : Ref Ctxt Defs -> ClosedTerm -> Core ()
-executeExpr c tm
+executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
+executeExpr c execDir tm
     = do tmp <- coreLift $ tmpName
-         let outn = tmp ++ ".rkt"
+         let outn = execDir ++ dirSep ++ tmp ++ ".rkt"
          compileToRKT c tm outn
          racket <- coreLift findRacket
          coreLift $ system (racket ++ " " ++ outn)

--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -135,6 +135,7 @@ mkdirs (d :: ds)
 isDirSep : Char -> Bool
 isDirSep c = cast c == dirSep
 
+export
 splitDir : String -> List String
 splitDir = split isDirSep
 


### PR DESCRIPTION
If you want to open a file in an Idris2 program, you need to use its absolute path because `--exec` chdirs somewhere else to exec the Scheme. This patch fixes that.

This is mostly an attempt to get it done and move on so if you prefer to have something cleaner, I can have another go at it.