### PR TITLE
[ performance ] rewrite-free concatMap

### DIFF
--- a/src/Text/Lexer.idr
+++ b/src/Text/Lexer.idr
@@ -44,7 +44,7 @@ choice = choiceMap id
 
 ||| Sequence a list of recognisers. Guaranteed to consume input if the list is
 ||| non-empty and the recognisers consume.
-concat : (xs : List (Recognise c)) -> Recognise (c && isCons xs)
+concat : (xs : List (Recognise c)) -> Recognise (isCons xs && c)
 concat = concatMap id
 
 ||| Recognise a specific character.


### PR DESCRIPTION
Simply removing rewrites took me down from a user time of ~1m8s
to ~54s when running `make test`. The (small) code duplication
in `scan` is a bit annoying.

We could have a core unindexed data structure and then only export
pseudo-constructors with the right phantom arguments. Not sure it
is worth it yet though.

A more principled solution would of course be to make sure the backend
gets rid of the code corresponding to rewrites altogether!