### PR TITLE
[ new ] interactive test runner

### DIFF
--- a/.ci-dockerfiles/ci-run.dockerfile
+++ b/.ci-dockerfiles/ci-run.dockerfile
@@ -4,4 +4,4 @@ copy . /Idris2-dev
 workdir /Idris2-dev
 run make idris2
 run make libs
-run make test
+run make test INTERACTIVE=''

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -4,6 +4,9 @@ import System
 
 %default covering
 
+------------------------------------------------------------------------
+-- Test cases
+
 ttimpTests : List String
 ttimpTests
     = ["basic001", "basic002", "basic003", "basic004", "basic005",
@@ -100,6 +103,39 @@ ideModeTests : List String
 ideModeTests
   =  [ "ideMode001", "ideMode002", "ideMode003" ]
 
+------------------------------------------------------------------------
+-- Options
+
+||| Options for the test driver.
+record Options where
+  constructor MkOptions
+  ||| Name of the idris2 executable
+  idris2      : String
+  ||| Should we only run some specific cases?
+  onlyNames   : List String
+  ||| Should we run the test suite interactively?
+  interactive : Bool
+
+usage : String
+usage = "Usage: runtests <idris2 path> [--interactive] [--only [NAMES]]"
+
+options : List String -> Maybe Options
+options args = case args of
+    (_ :: idris2 :: rest) => go rest (MkOptions idris2 [] False)
+    _ => Nothing
+
+  where
+
+    go : List String -> Options -> Maybe Options
+    go rest opts = case rest of
+      []                      => pure opts
+      ("--interactive" :: xs) => go xs (record { interactive = True } opts)
+      ("--only" :: xs)        => pure $ record { onlyNames = xs } opts
+      _ => Nothing
+
+------------------------------------------------------------------------
+-- Actual test runner
+
 chdir : String -> IO Bool
 chdir dir
     = do ok <- foreign FFI_C "chdir" (String -> IO Int) dir
@@ -110,21 +146,48 @@ fail err
     = do putStrLn err
          exitWith (ExitFailure 1)
 
-runTest : String -> String -> IO Bool
-runTest prog testPath
+runTest : Options -> String -> IO Bool
+runTest opts testPath
     = do chdir testPath
          isSuccess <- runTest'
          chdir "../.."
          pure isSuccess
     where
+        getAnswer : IO Bool
+        getAnswer = do
+          str <- getLine
+          case str of
+            "y" => pure True
+            "n" => pure False
+            _   => do putStrLn "Invalid Answer."
+                      getAnswer
+
+        mayOverwrite : Bool -> String -> IO ()
+        mayOverwrite missing out = do
+          putStr $ unlines $ if missing
+            then [ "Golden value missing. I computed the following result:"
+                 , out
+                 , "Accept new golden value? [yn]"
+                 ]
+            else [ "Golden value differs from actual value."
+                 , "Accept actual value as new golden value? [yn]"
+                 ]
+          b <- getAnswer
+          when b $ do Right _ <- writeFile "expected" out
+                          | Left err => print err
+                      pure ()
+
         runTest' : IO Bool
         runTest'
             = do putStr $ testPath ++ ": "
-                 system $ "sh ./run " ++ prog ++ " | tr -d '\\r' > output"
+                 system $ "sh ./run " ++ idris2 opts ++ " | tr -d '\\r' > output"
                  Right out <- readFile "output"
                      | Left err => do print err
                                       pure False
                  Right exp <- readFile "expected"
+                     | Left FileNotFound => do
+                         if interactive opts then mayOverwrite True out else print FileNotFound
+                         pure False
                      | Left err => do print err
                                       pure False
 
@@ -136,6 +199,7 @@ runTest prog testPath
                       printLn exp
                       putStrLn "Given:"
                       printLn out
+                      when (interactive opts) $ mayOverwrite False out
 
                  pure (out == exp)
 
@@ -163,32 +227,37 @@ findChez
     = do Just chez <- getEnv "CHEZ" | Nothing => pathLookup
          pure $ Just chez
 
-runChezTests : String -> List String -> IO (List Bool)
-runChezTests prog tests
+runChezTests : Options -> List String -> IO (List Bool)
+runChezTests opts tests
     = do chexec <- findChez
          maybe (do putStrLn "Chez Scheme not found"
                    pure [])
                (\c => do putStrLn $ "Found Chez Scheme at " ++ c
-                         traverse (runTest prog) tests)
+                         traverse (runTest opts) tests)
                chexec
+
+filterTests : Options -> List String -> List String
+filterTests opts = case onlyNames opts of
+  [] => id
+  xs => filter (\ name => any (`isInfixOf` name) xs)
 
 main : IO ()
 main
     = do args <- getArgs
-         let (_ :: idris2 :: _) = args
-              | _ => do putStrLn "Usage: runtests <idris2 path> [--only <name>]"
-         let filterTests = case drop 2 args of
-              ("--only" :: onlyName :: _) => filter (\testName => isInfixOf onlyName testName)
-              _ => id
+         let (Just opts) = options args
+              | _ => do print args
+                        putStrLn usage
          let filteredNonCGTests =
-              filterTests $ concat [testPaths "ttimp" ttimpTests,
-                                    testPaths "idris2" idrisTests,
-                                    testPaths "typedd-book" typeddTests,
-                                    testPaths "ideMode" ideModeTests]
-         let filteredChezTests = filterTests (testPaths "chez" chezTests)
-         nonCGTestRes <- traverse (runTest idris2) filteredNonCGTests
+              filterTests opts $ concat
+                 [ testPaths "ttimp" ttimpTests
+                 , testPaths "idris2" idrisTests
+                 , testPaths "typedd-book" typeddTests
+                 , testPaths "ideMode" ideModeTests
+                 ]
+         let filteredChezTests = filterTests opts (testPaths "chez" chezTests)
+         nonCGTestRes <- traverse (runTest opts) filteredNonCGTests
          chezTestRes <- if length filteredChezTests > 0
-              then runChezTests idris2 filteredChezTests
+              then runChezTests opts filteredChezTests
               else pure []
          let res = nonCGTestRes ++ chezTestRes
          putStrLn (show (length (filter id res)) ++ "/" ++ show (length res)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,8 @@
 IDRIS2 = ../../../idris2
+INTERACTIVE ?= --interactive
 
 test:
-	@../runtests $(IDRIS2) --only $(only)
+	@../runtests $(IDRIS2) $(INTERACTIVE) --only $(only)
 
 clean:
 	find . -name '*.ibc' | xargs rm -f


### PR DESCRIPTION
New interactive mode for the test runner.

* Print diff in case of mismatch (using `git diff`)
* Ask user whether they want to overwrite the current golden value

New options syntax for the test runner.

* `--interactive` flag
* `--only` should be the *last* flag and followed by a *list* of cases of interest. As before, if the list is empty we run all the tests.