### PR TITLE
[ fix #279 ] comment delimiters with more than one dash

### DIFF
--- a/tests/idris2/basic037/Comments.idr
+++ b/tests/idris2/basic037/Comments.idr
@@ -1,3 +1,11 @@
+{-------------------------}
+-- These should be
+-- ignored
+{- {---------------} -}
+
+-- Comments should have the right to be empty:
+--
+
 -- This is a valid comment {-
 -- It should not lead to a parse error if nested in a
 -- multiline comment
@@ -21,3 +29,11 @@ myString = "Similarly, this is a valid string literal {- "
 -- So we should be able to put it in a multiline comment
 
 -}
+
+
+{------------- Some people {---- like ---}
+  {- comments with
+     weird
+ ----------}
+ closing delimiters
+ --}

--- a/tests/idris2/basic037/Issue279.idr
+++ b/tests/idris2/basic037/Issue279.idr
@@ -1,0 +1,12 @@
+module Main
+
+{-- comment 1 --}
+
+someFunction : IO ()
+
+{-- comment 2 --}
+
+main : IO ()
+main = do
+    someFunction
+    pure ()

--- a/tests/idris2/basic037/expected
+++ b/tests/idris2/basic037/expected
@@ -1,2 +1,4 @@
 1/1: Building Comments (Comments.idr)
 Main> Bye for now!
+1/1: Building Issue279 (Issue279.idr)
+Main> Bye for now!

--- a/tests/idris2/basic037/run
+++ b/tests/idris2/basic037/run
@@ -1,3 +1,4 @@
 echo ':q' | $1 --no-banner --no-prelude Comments.idr
+echo ':q' | $1 --no-banner Issue279.idr
 
 rm -rf build


### PR DESCRIPTION
This adds support for comments of the form:

`{--------------- (...) ---------------}`

and banners of the form

`{-------------------------------------}`

Previously these would have been parsed as an opening delimiter
followed by a line comment until the end of the line i.e. the
closing delimiter would have been ignored.