### PR TITLE
RFC: Add mathematical/arrows unicode operator support

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -51,6 +51,8 @@ idrisTests
        "literate001", "literate002", "literate003", "literate004",
        "literate005", "literate006", "literate007", "literate008",
        "literate009", "literate010", "literate011", "literate012",
+       -- Unicode
+       "unicode001",
        -- Interfaces
        "interface001", "interface002", "interface003", "interface004",
        "interface005", "interface006", "interface007", "interface008",

--- a/tests/idris2/unicode001/Unicode.idr
+++ b/tests/idris2/unicode001/Unicode.idr
@@ -1,0 +1,9 @@
+module Unicode
+
+infix 6 ≡, ≢
+
+public export
+interface UnicodeEq a where
+    (≡) : a → a → Bool
+    (≢) : a → a → Bool
+

--- a/tests/idris2/unicode001/expected
+++ b/tests/idris2/unicode001/expected
@@ -1,0 +1,1 @@
+1/1: Building Unicode (Unicode.idr)

--- a/tests/idris2/unicode001/run
+++ b/tests/idris2/unicode001/run
@@ -1,0 +1,3 @@
+$1 -c Unicode.idr
+
+rm -rf build/


### PR DESCRIPTION
Major change:
 - Support Mathematical Operators and Arrows as Symbols/Operators

From [a commit](https://github.com/edwinb/Idris2/commit/1a4f42425963cc414997d33fc9f4b8bac9fc1fbf) in this repo:
> While we're at it, Idris 1 supports unicode identifiers (although we don't encourage it :)) so this allows any characeter >127 in an identifier.

Though from [Idris 1 FAQ [2013]](https://github.com/idris-lang/Idris-dev/blob/master/docs/faq/faq.rst):
>  Perhaps in a few years time things will be different and software will cope better and it will make sense to revisit this. For now, however, Idris will not be offering arbitrary Unicode symbols in operators.

This doesn't allow any arbitrary unicode, it adds the following 2 blocks:
 - [Mathematical Operators](https://unicode-table.com/en/blocks/mathematical-operators/)
 - [Arrows](https://unicode-table.com/en/blocks/arrows/)

This is a work in progress. I want to add a pragma or compiler option to enable this (So that this extra operators are opt-in) however since there is the possibility that unicode operators (even non-arbitrary) aren't desirable I would leave this as currently is for people to evaluate before implementing flags/pragmas to control this feature.