### PR TITLE
Refactor Parser.Lexer.{ident, OpCode} for reuse in IDEMode

### DIFF
--- a/src/Core/Name.idr
+++ b/src/Core/Name.idr
@@ -56,7 +56,7 @@ showSep sep (x :: xs) = x ++ sep ++ showSep sep xs
 ||| Check whether a given character is a valid identifier character
 export
 identChar : Char -> Bool
-identChar x = isAlphaNum x || x == '_' || x == '\''
+identChar x = isAlphaNum x || x == '_' || x == '\'' ||  x > chr 127
 
 export Show Name where
   show (NS ns n) = showSep "." (reverse ns) ++ "." ++ show n

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -72,11 +72,10 @@ toTokList (POp fc opn l r)
          let op = nameRoot opn
          case lookup op (infixes syn) of
               Nothing =>
-                let ops = unpack opChars in
-                    if any (\x => x `elem` ops) (unpack op)
-                       then throw (GenericMsg fc $ "Unknown operator '" ++ op ++ "'")
-                       else do rtoks <- toTokList r
-                               pure (Expr l :: Op fc opn backtickPrec :: rtoks)
+                  if any isOpChar (unpack op)
+                     then throw (GenericMsg fc $ "Unknown operator '" ++ op ++ "'")
+                     else do rtoks <- toTokList r
+                             pure (Expr l :: Op fc opn backtickPrec :: rtoks)
               Just (Prefix, _) =>
                       throw (GenericMsg fc $ "'" ++ op ++ "' is a prefix operator")
               Just (fix, prec) =>

--- a/src/Idris/IDEMode/MakeClause.idr
+++ b/src/Idris/IDEMode/MakeClause.idr
@@ -9,7 +9,7 @@ import Parser.Unlit
 showRHSName : Name -> String
 showRHSName n
     = let fn = show (dropNS n) in
-          if any (flip elem (unpack opChars)) (unpack fn)
+          if any isOpChar (unpack fn)
              then "op"
              else fn
 

--- a/src/Idris/IDEMode/Parser.idr
+++ b/src/Idris/IDEMode/Parser.idr
@@ -1,3 +1,6 @@
+||| Slightly different lexer than the source language because we are more free
+||| as to what can be identifiers, and fewer tokens are supported. But otherwise,
+||| we can reuse the standard stuff
 module Idris.IDEMode.Parser
 
 import Idris.IDEMode.Commands
@@ -7,34 +10,17 @@ import Parser.Lexer
 import Parser.Support
 import Text.Lexer
 
--- Slightly different lexer than the source language because we are more free
--- as to what can be identifiers, and fewer tokens are supported. But otherwise,
--- we can reuse the standard stuff
-
 %hide Lexer.symbols
 
 symbols : List String
 symbols = ["(", ":", ")"]
-
-ident : Lexer
-ident = pred startIdent <+> many (pred validIdent)
-  where
-    startIdent : Char -> Bool
-    startIdent '_' = True
-    startIdent x = isAlpha x
-
-    validIdent : Char -> Bool
-    validIdent '_' = True
-    validIdent '-' = True
-    validIdent '\'' = True
-    validIdent x = isAlphaNum x
 
 ideTokens : TokenMap Token
 ideTokens =
     map (\x => (exact x, Symbol)) symbols ++
     [(digits, \x => Literal (cast x)),
      (stringLit, \x => StrLit (stripQuotes x)),
-     (ident, Ident),
+     (identRelaxed, Ident),
      (space, Comment)]
   where
     stripQuotes : String -> String

--- a/src/Idris/IDEMode/TokenLine.idr
+++ b/src/Idris/IDEMode/TokenLine.idr
@@ -1,7 +1,7 @@
+||| Tokenise a source line for easier processing
 module Idris.IDEMode.TokenLine
 
--- Tokenise a source line for easier processing
-
+import Parser.Lexer
 import Text.Lexer
 
 public export
@@ -14,24 +14,12 @@ data SourcePart
   | Equal
   | Other String
 
-ident : Lexer
-ident = pred startIdent <+> many (pred validIdent)
-  where
-    startIdent : Char -> Bool
-    startIdent '_' = True
-    startIdent x = isAlpha x
-
-    validIdent : Char -> Bool
-    validIdent '_' = True
-    validIdent '\'' = True
-    validIdent x = isAlphaNum x
-
 holeIdent : Lexer
-holeIdent = is '?' <+> ident
+holeIdent = is '?' <+> identStrict
 
 srcTokens : TokenMap SourcePart
 srcTokens =
-    [(ident, Name),
+    [(identStrict, Name),
      (holeIdent, \x => HoleName (assert_total (strTail x))),
      (space, Whitespace),
      (is '{', const LBrace),
@@ -47,4 +35,3 @@ tokens str
            -- number to read when storing spans in the file
            (srctoks, (l, c, rest)) =>
               map tok srctoks ++ (if rest == "" then [] else [Other rest])
-


### PR DESCRIPTION
Related Diff: https://github.com/edwinb/Idris2/commit/1a4f42425963cc414997d33fc9f4b8bac9fc1fbf#diff-5e7cbe76487381054be3ce2d96369916

Reusing the same function from the Idris Parser will avoid any future out of sync issues when the ident lexer changes. Also some cleanup of opChar.

There was an out of sync issue where identifiers that idris accepted like `álo` wouldn't be recognized by IDEMode.