### PR TITLE
WIP: Bugfix named interfaces

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1219,23 +1219,22 @@ implDecl fname indents
          col <- column
          option () (keyword "implementation")
          iname <- option Nothing (do symbol "["
-                                     iname <- name
+                                     iname <- unqualifiedName'
                                      symbol "]"
                                      pure (Just iname))
          impls <- implBinds fname indents
          cons <- constraints fname indents
-         n <- name
+         n <- identName
          params <- many (simpleExpr fname indents)
          nusing <- option [] (do keyword "using"
-                                 names <- some name
+                                 names <- some identName
                                  pure names)
          body <- optional (do keyword "where"
                               blockAfter col (topDecl fname))
          atEnd indents
          end <- location
-         pure (PImplementation (MkFC fname start end)
-                         vis Single impls cons n params iname nusing
-                         (map (collectDefs . concat) body))
+         pure (PImplementation (MkFC fname start end) vis Single impls cons n
+                       params iname nusing (map (collectDefs . concat) body))
 
 fieldDecl : FileName -> IndentInfo -> Rule (List PField)
 fieldDecl fname indents

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -211,10 +211,11 @@ mutual
                     List PDecl ->
                     PDecl
        PImplementation : FC ->
-                         Visibility -> Pass ->
+                         Visibility ->
+                         Pass ->
                          (implicits : List (Name, RigCount, PTerm)) ->
                          (constraints : List (Maybe Name, PTerm)) ->
-                         Name ->
+                         (interfaceName : Name) ->
                          (params : List PTerm) ->
                          (implName : Maybe Name) ->
                          (nusing : List Name) ->

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -55,7 +55,7 @@ idrisTests
        "interface001", "interface002", "interface003", "interface004",
        "interface005", "interface006", "interface007", "interface008",
        "interface009", "interface010", "interface011", "interface012",
-       "interface013", "interface014", "interface015",
+       "interface013", "interface014", "interface015", "interface016",
        -- Miscellaneous REPL
        "interpreter001",
        -- Implicit laziness, lazy evaluation

--- a/tests/idris2/interface016/NamedInterface.idr
+++ b/tests/idris2/interface016/NamedInterface.idr
@@ -1,0 +1,14 @@
+module NamedInterface
+
+interface MagmaT a where
+  op : a -> a -> a
+
+interface MagmaT a => SemigroupT a where
+  assoc : (x, y, z: a) -> (x `op` y) `op` z = x `op` (y `op` z)
+
+[NamedMagma] MagmaT Bool where
+  False `op` False = False
+  _     `op` _     = True
+
+[NamedSemigroup] SemigroupT Bool using NamedMagma where
+  assoc = ?hole

--- a/tests/idris2/interface016/expected
+++ b/tests/idris2/interface016/expected
@@ -1,0 +1,1 @@
+1/1: Building NamedInterface (NamedInterface.idr)

--- a/tests/idris2/interface016/run
+++ b/tests/idris2/interface016/run
@@ -1,0 +1,4 @@
+$1 NamedInterface.idr --check
+
+rm -rf build
+


### PR DESCRIPTION
Closes #291

There seemed to be an issue of what was expected of interface implementations, in particular `name` appears to be a grammar for symbols/operators and not of identifiers.

Additionally something is off with the elaborator but I haven't been able to pin what.

