### PR TITLE
Explicit bind for do notation

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -661,7 +661,7 @@ mutual
       = do start <- location
            keyword "do"
            mbBind <- optional $
-             symbol "{" *> expr pdef fname indents <* symbol "}"
+             symbol "@{" *> expr pdef fname indents <* symbol "}"
            actions <- block (doAct fname)
            end <- location
            pure (PDoBlock (MkFC fname start end) mbBind (concat actions))

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -660,9 +660,11 @@ mutual
   doBlock fname indents
       = do start <- location
            keyword "do"
+           mbBind <- optional $
+             symbol "{" *> expr pdef fname indents <* symbol "}"
            actions <- block (doAct fname)
            end <- location
-           pure (PDoBlock (MkFC fname start end) (concat actions))
+           pure (PDoBlock (MkFC fname start end) mbBind (concat actions))
 
   lowerFirst : String -> Bool
   lowerFirst "" = False


### PR DESCRIPTION
When I make a mistake in the middle of a `do` block, the errors I get tend to be quite unhelpful. Consider this program, where I try to add `1` to `()`. (The example is a bit contrived to get a short program with multiple plausible disambiguations of `>>=`.)
```idris
(>>=) : IO a -> IO b -> IO b
(>>=) f x = f *> x

main : IO ()
main = do
  printLn $ "foo"
  printLn $ "moo"
  map (+1) $ do
    printLn $ "boo"
  printLn $ "moo"
  printLn $ "moo"
  printLn $ "moo"
```
The above program produces these errors:
```
1/1: Building x (x.idr)
x.idr:10:3--11:3:While processing right hand side of main at x.idr:5:1--13:1:
Sorry, I can't find any elaboration which works. All errors:
If Main.>>=: Sorry, I can't find any elaboration which works. All errors:
If Main.>>=: Sorry, I can't find any elaboration which works. All errors:
If Main.>>=: When unifying ?_ -> IO () and IO ?b
Mismatch between:
	?_ -> IO ()
and
	IO ?b

If Prelude.>>=: When unifying ?_ -> IO () and IO ?b
Mismatch between:
	?_ -> IO ()
and
	IO ?b


If Prelude.>>=: When unifying ?_ -> IO () and IO ?b
Mismatch between:
	?_ -> IO ()
and
	IO ?b


If Prelude.>>=: Sorry, I can't find any elaboration which works. All errors:
If Main.>>=: When unifying ?_ -> IO () and IO ?b
Mismatch between:
	?_ -> IO ()
and
	IO ?b

If Prelude.>>=: When unifying ?_ -> IO () and IO ?b
Mismatch between:
	?_ -> IO ()
and
	IO ?b


Error(s) building file x.idr
```
There's no mention of `Num` or `()` or any hint of what's _really_ wrong because the disambiguation errors get in the way.

For debugging, or maybe for real-life use, too, I always wanted to say explicitly which bind I mean.
```idris
(>>=) : IO a -> IO b -> IO b
(>>=) f x = f *> x

main : IO ()
main = do @{Prelude.(>>=)}  -- aha!
  printLn $ "foo"
  printLn $ "moo"
  map (+1) $ do
    printLn $ "boo"
  printLn $ "moo"
  printLn $ "moo"
  printLn $ "moo"
```
The resulting error message points exactly where it should:
```
1/1: Building x (x.idr)
x.idr:8:7--8:12:While processing right hand side of main at x.idr:5:1--13:1:
Can't find an implementation for Num ()
Error(s) building file x.idr
```

This patch adds this functionality. I don't really care about the syntax; I chose `@{...}` to avoid clashing with `do { f ; x }` but I could also imagine `do with (Prelude.(>>=))` or something else.