### PR TITLE
Fix builds on *BSD

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,11 +1,13 @@
+include config.mk
+
 .PHONY: idris2 clean
 
 all: idris2
 
 idris2: idris2.c
-	make -C rts
-	$(CC) $(OPT) idris2.c -o idris2 -I rts -L rts -lidris_rts -lgmp -lm
+	$(MAKE) -C rts
+	$(CC) $(OPT) idris2.c -o idris2 -I rts -L rts -lidris_rts $(GMP_LIB_DIR) -lgmp -lm
 
 clean:
-	make -C rts clean
+	${MAKE} -C rts clean
 	rm -f idris2

--- a/dist/config.mk
+++ b/dist/config.mk
@@ -1,29 +1,20 @@
-RANLIB          ?=ranlib
-CFLAGS          :=-O2 -Wall -std=c99 -pipe -fdata-sections -ffunction-sections -D_POSIX_C_SOURCE=200809L $(CFLAGS)
+RANLIB ?=ranlib
+CFLAGS :=-O2 -Wall -std=c99 -pipe -fdata-sections -ffunction-sections -D_POSIX_C_SOURCE=200809L $(CFLAGS)
 
-ifneq (, $(findstring bsd, $(MACHINE)))
-	GMP_INCLUDE_DIR      :=
-else
-	GMP_INCLUDE_DIR      :=-I/usr/local/include
-endif
-
-MACHINE         := $(shell $(CC) -dumpmachine)
-ifneq (, $(findstring darwin, $(MACHINE)))
-	OS      :=darwin
-else ifneq (, $(findstring cygwin, $(MACHINE)))
-	OS      :=windows
-else ifneq (, $(findstring mingw, $(MACHINE)))
-	OS      :=windows
-else ifneq (, $(findstring windows, $(MACHINE)))
-	OS      :=windows
-else
-	OS      :=unix
-endif
-
-ifeq ($(OS),darwin)
-	SHLIB_SUFFIX    :=.dylib
+ifeq ($(OS),bsd)
+	GMP_INCLUDE_DIR =-I/usr/local/include
+	GMP_LIB_DIR     =-L/usr/local/lib
+	SHLIB_SUFFIX    =.so
+else ifeq ($(OS),darwin)
+	GMP_INCLUDE_DIR =
+	GMP_LIB_DIR     =
+	SHLIB_SUFFIX    =.dylib
 else ifeq ($(OS),windows)
-	SHLIB_SUFFIX    :=.DLL
+	GMP_INCLUDE_DIR =
+	GMP_LIB_DIR     =
+	SHLIB_SUFFIX    =.DLL
 else
-	SHLIB_SUFFIX    :=.so
+	GMP_INCLUDE_DIR =
+	GMP_LIB_DIR     =
+	SHLIB_SUFFIX    =.so
 endif

--- a/dist/rts/Makefile
+++ b/dist/rts/Makefile
@@ -1,14 +1,14 @@
 include ../config.mk
 
-OBJS = idris_rts.o idris_heap.o idris_gc.o idris_gmp.o idris_bitstring.o \
-       idris_opts.o idris_stats.o idris_utf8.o idris_stdfgn.o \
-       idris_buffer.o getline.o idris_net.o
-HDRS = idris_rts.h idris_heap.h idris_gc.h idris_gmp.h idris_bitstring.h \
-       idris_opts.h idris_stats.h idris_stdfgn.h idris_net.h \
-       idris_buffer.h idris_utf8.h getline.h
-CFLAGS := $(CFLAGS)
-CFLAGS += $(GMP_INCLUDE_DIR) $(GMP) -DIDRIS_TARGET_OS="\"$(OS)\""
-CFLAGS += -DIDRIS_TARGET_TRIPLE="\"$(MACHINE)\""
+OBJS =idris_rts.o idris_heap.o idris_gc.o idris_gmp.o idris_bitstring.o \
+      idris_opts.o idris_stats.o idris_utf8.o idris_stdfgn.o \
+      idris_buffer.o getline.o idris_net.o
+HDRS =idris_rts.h idris_heap.h idris_gc.h idris_gmp.h idris_bitstring.h \
+      idris_opts.h idris_stats.h idris_stdfgn.h idris_net.h \
+      idris_buffer.h idris_utf8.h getline.h
+CFLAGS :=$(CFLAGS)
+CFLAGS +=$(GMP_INCLUDE_DIR) $(GMP) -DIDRIS_TARGET_OS="\"$(OS)\""
+CFLAGS +=-DIDRIS_TARGET_TRIPLE="\"$(MACHINE)\""
 
 ifeq ($(OS), windows)
 	OBJS += windows/win_utils.o
@@ -23,7 +23,9 @@ endif
 
 LIBTARGET = libidris_rts.a
 
-build: $(LIBTARGET) $(DYLIBTARGET)
+.PHONY: build install clean
+
+build: $(LIBTARGET)
 
 $(LIBTARGET) : $(OBJS)
 	$(AR) rc $(LIBTARGET) $(OBJS)
@@ -37,5 +39,3 @@ clean :
 	rm -f $(OBJS) $(LIBTARGET) $(DYLIBTARGET)
 
 $(OBJS): $(HDRS)
-
-.PHONY: build install clean

--- a/libs/network/Makefile
+++ b/libs/network/Makefile
@@ -1,19 +1,6 @@
 RANLIB      ?=ranlib
 AR          ?=ar
 
-MACHINE         := $(shell $(CC) -dumpmachine)
-ifneq (, $(findstring darwin, $(MACHINE)))
-	OS      :=darwin
-else ifneq (, $(findstring cygwin, $(MACHINE)))
-	OS      :=windows
-else ifneq (, $(findstring mingw, $(MACHINE)))
-	OS      :=windows
-else ifneq (, $(findstring windows, $(MACHINE)))
-	OS      :=windows
-else
-	OS      :=unix
-endif
-
 SHLIB_SUFFIX    :=.so
 
 LIBNAME=idris_net


### PR DESCRIPTION
This makes it so gmake gets used instead of make on *BSD and refactors how
platforms are handled in general.