### PR TITLE
Make a couple improvements for the Racket backend

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,3 +77,13 @@ After installing chicken scheme you may need to install the 'numbers' package.
 Racket is available from:
 
 + https://download.racket-lang.org/
+
+The following packages are required in order to run Idris:
+
+- base
+- racket-lib
+- compiler-lib
+- r6rs-lib
+- math-lib
+
+These can be installed with `raco setup` and `raco pkg install`.

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -33,6 +33,7 @@ findRacoExe =
 schHeader : String -> String
 schHeader libs
   = "#lang racket/base\n" ++
+    "(require racket/math)\n" ++ -- for math ops
     "(require racket/promise)\n" ++ -- for force/delay
     "(require racket/system)\n" ++ -- for system
     "(require rnrs/bytevectors-6)\n" ++ -- for buffers


### PR DESCRIPTION
This fixes an error that would get thrown when attempting to use Racket as a backend:
```
/tmp/tmp.0.tSCpq7Hki.rkt:16:42: exact-floor: unbound identifier
  in: exact-floor
  location...:
   /tmp/tmp.0.tSCpq7Hki.rkt:16:42
  context...:
   do-raise-syntax-error
   for-loop
   [repeats 1 more time]
   finish-bodys
   lambda-clause-expander
   loop
   [repeats 4 more times]
   finish-expanding-body
   for-loop
   finish-bodys
   lambda-clause-expander
   for-loop
   loop
   [repeats 7 more times]
   module-begin-k
   expand-module
   ...
```

OpenBSD's Racket package is minimal, so packages that are probably included on other platforms aren't included with it, so this also adds documentation for which ones are needed to run Idris 2.