### PR TITLE
'using' multiple named instances in scope fix

### DIFF
--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -170,6 +170,8 @@ elabImplementation {vars} fc vis pass env nest is cons iname ps impln nusing mbo
                log 5 $ "Missing methods: " ++ show missing
 
                -- Add the 'using' hints
+               defs <- get Ctxt
+               let hs = openHints defs -- snapshot open hint state
                log 10 $ "Open hints: " ++ (show (impName :: nusing))
                traverse_ (\n => do n' <- checkUnambig fc n
                                    addOpenHint n') nusing
@@ -200,8 +202,6 @@ elabImplementation {vars} fc vis pass env nest is cons iname ps impln nusing mbo
 
                -- If it's a named implementation, add it as a global hint while
                -- elaborating the record and bodies
-               defs <- get Ctxt
-               let hs = openHints defs
                maybe (pure ()) (\x => addOpenHint impName) impln
 
                -- Make sure we don't use this name to solve parent constraints

--- a/tests/idris2/reg016/Using.idr
+++ b/tests/idris2/reg016/Using.idr
@@ -6,9 +6,16 @@ interface MagmaT a where
 interface MagmaT a => SemigroupT a where
   assoc: (x, y, z: a) -> (x `op` y) `op` z = x `op` (y `op` z)
 
-[NamedMagma] MagmaT Bool where
+[NamedMagma1] MagmaT Bool where
   False `op` False = False
   _     `op` _     = True
 
-[NamedSemigroup] SemigroupT Bool using NamedMagma where
-  assoc = ?hole
+[NamedMagma2] MagmaT Bool where
+  True `op` True = True
+  _    `op` _    = False
+
+[NamedSemigroup1] SemigroupT Bool using NamedMagma1 where
+  assoc = ?hole1
+
+[NamedSemigroup2] SemigroupT Bool using NamedMagma2 where
+  assoc = ?hole2


### PR DESCRIPTION
Change where the open hints is snapshotted. This is done too late, causing named implementations to remain in scope.
addressing https://github.com/edwinb/Idris2/issues/307
caused by the reordering in https://github.com/edwinb/Idris2/commit/d39c701f280c4ca46f9ca2ba36b59eea3958277d