### PR TITLE
Including a Gambit Scheme backend

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 # Installation
 
 Idris 2 is built using Idris, and provides support for two default code
-generation targets: Chez Scheme, and Racket. To build from source, it requires
+generation targets: Chez Scheme, Racket, and Gambit. To build from source, it requires
 at least Idris version 1.3.2 (see https://www.idris-lang.org/pages/download.html). You
 can also build from the generated C.
 
@@ -64,7 +64,7 @@ you run `./configure --threads` to build multithreading support in.
 
 ### Chicken
 
-Chicken scheme offers binary distributions (and source tar balls) from
+Chicken Scheme offers binary distributions (and source tar balls) from
 
 + https://code.call-cc.org/
 
@@ -87,3 +87,14 @@ The following packages are required in order to run Idris:
 - math-lib
 
 These can be installed with `raco setup` and `raco pkg install`.
+
+### Gambit
+
+Gambit Scheme offers binary releases and source tarballs on
+http://gambitscheme.org.
+
+GNU/Linux users can usually find a package on their distribution under one of
+the following names: `gambit`, `gambit-c` or `gambc`.
+
+The default backend of Gambit is C, so you are expected to have a C compiler
+(GCC preferred).

--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,11 @@ install-support:
 	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
 	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chicken
 	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/racket
+	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
 	install support/chez/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
 	install support/chicken/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chicken
 	install support/racket/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/racket
+	install support/gambit/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
 
 install-exec:
 	mkdir -p ${PREFIX}/bin

--- a/Notes/Directives.md
+++ b/Notes/Directives.md
@@ -112,7 +112,7 @@ Syntax:
 The given instructions are passed directly to the code generator, to be
 interpreted in a backend-specific way.
 
-Currently known backends are: `chez`, `chicken` and `racket`.
+Currently known backends are: `chez`, `chicken`, `racket` and `gambit`.
 
 ## Backend Specific Directives
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Summary of new features:
 + Better type checker implementation which minimises the need for compile
   time evaluation.
 + New Chez Scheme based back end which both compiles and runs faster than the
-  default Idris 1 back end. (Also, optionally, Chicken Scheme and Racket can
-  be used as targets).
+  default Idris 1 back end. (Also, optionally, Chicken Scheme, Racket and Gambit
+  can be used as targets).
 + Everything works faster :).
 
 A significant change in the implementation is that there is an intermediate

--- a/docs/source/backends/gambit.rst
+++ b/docs/source/backends/gambit.rst
@@ -1,0 +1,36 @@
+****************************
+Gambit Scheme Code Generator
+****************************
+
+The Gambit Scheme code generator can be accessed via the REPL command:
+
+::
+
+    Main> :set cg gambit
+
+Ergo, to run Idris programs with this generator, you will need to install
+`Gambit Scheme <https://gambitscheme.org>`_. Gambit Scheme is free software,
+and available via most pacakge managers.
+
+You can compile an expression ``expr`` of type ``IO ()`` to an executable as
+follows, at the REPL:
+
+::
+
+    Main> :c execname expr
+
+...where ``execname`` is the name of the executable file. This will generate
+the following:
+
+* An executable binary ``build/exec/execname`` of the program.
+* A Gambit Scheme source file ``build/exec/execname.scm``, from which the
+  binary is generated.
+
+You can also execute an expression directly:
+
+::
+
+    Main> :exec expr
+
+Again, ``expr`` must have type ``IO ()``. This will generate a temporary
+Scheme file, and execute the Gambit interpreter on it.

--- a/docs/source/backends/index.rst
+++ b/docs/source/backends/index.rst
@@ -37,13 +37,14 @@ You can also execute expressions directly:
 
 Again, ``expr`` must have type ``IO ()``.
 
-There are two code generators provided in Idris 2, and (later) there will be
+There are three code generators provided in Idris 2, and (later) there will be
 a system for plugging in new code generators for a variety of targets. The
-default is to compile via Chez Scheme, with an alternative via Racket.
+default is to compile via Chez Scheme, with an alternative via Racket or Gambit.
 
 .. toctree::
    :maxdepth: 1
 
    chez
    racket
+   gambit
 

--- a/docs/source/ffi/ffi.rst
+++ b/docs/source/ffi/ffi.rst
@@ -24,8 +24,8 @@ example, in C:
 
 It is up to specific code generators to decide how to locate the function and
 the library. In this document, we will assume the default Chez Scheme code
-generator (the examples also work with the Racket code generator) and that the
-foreign language is C.
+generator (the examples also work with the Racket or Gambit code generator) and
+that the foreign language is C.
 
 Example
 -------

--- a/docs/source/ffi/index.rst
+++ b/docs/source/ffi/index.rst
@@ -12,7 +12,7 @@ Foreign Function Interface
    More information concerning the CC0 can be found online at: http://creativecommons.org/publicdomain/zero/1.0/
 
 Idris 2 is designed to support multiple code generators. The default target is
-Chez Scheme, with a Racket code generator also supported. However, the
+Chez Scheme, with Racket and Gambit code generators also supported. However, the
 intention is, as with Idris 1, to support multiple targets on multiple platforms,
 including e.g. JavaScript, JVM, .NET, and others yet to be invented.
 This makes the design of a foreign function interface (FFI), which calls

--- a/docs/source/updates/updates.rst
+++ b/docs/source/updates/updates.rst
@@ -646,8 +646,9 @@ Chez Scheme target
 ------------------
 
 The default code generator is, for the moment, `Chez Scheme
-<https://www.scheme.com/>`_. A Racket code generator is also available. There
-is not yet a way to plug in code generators as in Idris 1, but this is coming.
+<https://www.scheme.com/>`_. Racket and Gambit code generators are also
+available. There is not yet a way to plug in code generators as in Idris 1,
+but this is coming.
 To change the code generator, you can use the ``:set cg`` command:
 
 ::

--- a/idris2.ipkg
+++ b/idris2.ipkg
@@ -9,6 +9,7 @@ modules =
     Compiler.Scheme.Chez,
 --     Compiler.Scheme.Chicken,
     Compiler.Scheme.Racket,
+    Compiler.Scheme.Gambit,
     Compiler.Scheme.Common,
     Compiler.VMCode,
 

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -1,11 +1,12 @@
 package idris2api
 
-modules = 
+modules =
     Compiler.Common,
     Compiler.CompileExpr,
     Compiler.Inline,
     Compiler.Scheme.Chez,
     Compiler.Scheme.Racket,
+    Compiler.Scheme.Gambit,
     Compiler.Scheme.Common,
 
     Control.Delayed,

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -34,6 +34,7 @@ findGSC =
 
 schHeader : String
 schHeader = "(declare (block)
+         (inlining-limit 450)
          (standard-bindings)
          (extended-bindings)
          (not safe)

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -20,29 +20,31 @@ import System.Info
 
 %default covering
 
+-- TODO Look for gsi-script, then gsi
 findGSI : IO String
 findGSI =
   do env <- getEnv "GAMBIT_GSI"
      pure $ fromMaybe "/usr/bin/env -S gsi-script" env
 
+-- TODO Look for gsc-script, then gsc
 findGSC : IO String
 findGSC =
   do env <- getEnv "GAMBIT_GSC"
      pure $ fromMaybe "/usr/bin/env -S gsc-script" env
 
+-- TODO Tweak the header for optimal results
 schHeader : String
 schHeader = "(declare (block)
          (standard-bindings)
          (extended-bindings)
-         (not safe))\n\n"
+         (not safe))\n"
 
-schFooter : String
-schFooter = "\n"
-
--- XXX
 showGambitChar : Char -> String -> String
 showGambitChar '\\' = ("\\\\" ++)
-showGambitChar c = strCons c
+showGambitChar c
+   = if c < chr 32 -- XXX
+        then (("\\x" ++ asHex (cast c) ++ ";") ++)
+        else strCons c
 
 showGambitString : List Char -> String -> String
 showGambitString [] = id
@@ -53,17 +55,46 @@ gambitString : String -> String
 gambitString cs = strCons '"' (showGambitString (unpack cs) "\"")
 
 mutual
+  -- Primitive types have been converted to names for the purpose of matching
+  -- on types
+  tySpec : NamedCExp -> Core String
+  tySpec (NmCon fc (UN "Int") _ []) = pure "int"
+  tySpec (NmCon fc (UN "String") _ []) = pure "UTF-8-string"
+  tySpec (NmCon fc (UN "Double") _ []) = pure "double"
+  tySpec (NmCon fc (UN "Char") _ []) = pure "char"
+  tySpec (NmCon fc (NS _ n) _ [_])
+     = cond [(n == UN "Ptr", pure "(pointer void)")]
+          (throw (GenericMsg fc ("Can't pass argument of type " ++ show n ++ " to foreign function")))
+  tySpec (NmCon fc (NS _ n) _ [])
+     = cond [(n == UN "Unit", pure "void"),
+             (n == UN "AnyPtr", pure "(pointer void)")]
+          (throw (GenericMsg fc ("Can't pass argument of type " ++ show n ++ " to foreign function")))
+  tySpec ty = throw (GenericMsg (getFC ty) ("Can't pass argument of type " ++ show ty ++ " to foreign function"))
+
+  handleRet : String -> String -> String
+  handleRet "void" op = op ++ " " ++ mkWorld (schConstructor 0 [])
+  handleRet _ op = mkWorld op
+
+  getFArgs : NamedCExp -> Core (List (NamedCExp, NamedCExp))
+  getFArgs (NmCon fc _ 0 _) = pure []
+  getFArgs (NmCon fc _ 1 [ty, val, rest]) = pure $ (ty, val) :: !(getFArgs rest)
+  getFArgs arg = throw (GenericMsg (getFC arg) ("Badly formed c call argument list " ++ show arg))
+
   gambitPrim : Int -> ExtPrim -> List NamedCExp -> Core String
   gambitPrim i CCall [ret, NmPrimVal fc (Str fn), fargs, world]
-      = throw (InternalError ("Can't compile C FFI calls to Gambit yet")) -- TODO
+      = do args <- getFArgs fargs
+           argTypes <- traverse tySpec (map fst args)
+           retType <- tySpec ret
+           argsc <- traverse (schExp gambitPrim gambitString 0) (map snd args)
+           pure $ handleRet retType ("((c-lambda (" ++ showSep " " argTypes ++ ") "
+                    ++ retType ++ " " ++ show fn ++ ") "
+                    ++ showSep " " argsc ++ ")")
   gambitPrim i CCall [ret, fn, args, world]
       = pure "(error \"bad ffi call\")"
-  gambitPrim i GetStr [world]
-      = pure $ mkWorld "(read-line (current-input-port))"
   gambitPrim i GetField [NmPrimVal _ (Str s), _, _, struct,
                          NmPrimVal _ (Str fld), _]
       = do structsc <- schExp gambitPrim gambitString 0 struct
-           pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")" -- XXX
+           pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")"
   gambitPrim i GetField [_,_,_,_,_,_]
       = pure "(error \"bad getField\")"
   gambitPrim i SetField [NmPrimVal _ (Str s), _, _, struct,
@@ -71,7 +102,7 @@ mutual
       = do structsc <- schExp gambitPrim gambitString 0 struct
            valsc <- schExp gambitPrim gambitString 0 val
            pure $ mkWorld $
-                "(" ++ s ++ "-" ++ fld ++ "-set! " ++ structsc ++ " " ++ valsc ++ ")" -- XXX
+                "(" ++ s ++ "-" ++ fld ++ "-set! " ++ structsc ++ " " ++ valsc ++ ")"
   gambitPrim i SetField [_,_,_,_,_,_,_,_]
       = pure "(error \"bad setField\")"
   gambitPrim i SysCodegen []
@@ -85,37 +116,188 @@ data Loaded : Type where
 -- Label for noting which struct types are declared
 data Structs : Type where
 
--- TODO Support C FFI and libraries
+cftySpec : FC -> CFType -> Core String
+cftySpec fc CFUnit = pure "void"
+cftySpec fc CFInt = pure "int"
+cftySpec fc CFString = pure "UTF-8-string"
+cftySpec fc CFDouble = pure "double"
+cftySpec fc CFChar = pure "char"
+cftySpec fc CFPtr = pure "(pointer void)"
+cftySpec fc (CFIORes t) = cftySpec fc t
+cftySpec fc (CFStruct n t) = pure $ n ++ "*/nonnull"
+cftySpec fc (CFFun s t) = funTySpec [s] t
+  where
+    funTySpec : List CFType -> CFType -> Core String
+    funTySpec args (CFFun CFWorld t) = funTySpec args t
+    funTySpec args (CFFun s t) = funTySpec (s :: args) t
+    funTySpec args retty
+        = do rtyspec <- cftySpec fc retty
+             argspecs <- traverse (cftySpec fc) (reverse args)
+             pure $ "(function (" ++ showSep " " argspecs ++ ") " ++ rtyspec ++ ")"
+cftySpec fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
+                         " to foreign function"))
 
+cCall : {auto c : Ref Ctxt Defs} ->
+        {auto l : Ref Loaded (List String)} ->
+        FC -> (cfn : String) -> (clib : String) ->
+        List (Name, CFType) -> CFType -> Core (String, String)
+cCall fc cfn clib args ret
+    = do -- loaded <- get Loaded
+         -- lib <- if clib `elem` loaded
+         --           then pure ""
+         --           else do (fname, fullname) <- locate clib
+         --                   copyLib (fname, fullname)
+         --                   put Loaded (clib :: loaded)
+         --                   pure ""
+         argTypes <- traverse (\a => cftySpec fc (snd a)) args
+         retType <- cftySpec fc ret
+         let call = "((c-lambda (" ++ showSep " " argTypes ++ ") "
+                      ++ retType ++ " " ++ show cfn ++ ") "
+                      ++ showSep " " !(traverse buildArg args) ++ ")"
+
+         pure ("", case ret of -- XXX
+                        CFIORes _ => handleRet retType call
+                        _ => call)
+  where
+    mkNs : Int -> List CFType -> List (Maybe String)
+    mkNs i [] = []
+    mkNs i (CFWorld :: xs) = Nothing :: mkNs i xs
+    mkNs i (x :: xs) = Just ("cb" ++ show i) :: mkNs (i + 1) xs
+
+    applyLams : String -> List (Maybe String) -> String
+    applyLams n [] = n
+    applyLams n (Nothing :: as) = applyLams ("(" ++ n ++ " #f)") as
+    applyLams n (Just a :: as) = applyLams ("(" ++ n ++ " " ++ a ++ ")") as
+
+    mkFun : List CFType -> CFType -> String -> String
+    mkFun args ret n
+        = let argns = mkNs 0 args in
+              "(lambda (" ++ showSep " " (mapMaybe id argns) ++ ") "
+              ++ (applyLams n argns ++ ")")
+
+    notWorld : CFType -> Bool
+    notWorld CFWorld = False
+    notWorld _ = True
+
+    callback : String -> List CFType -> CFType -> Core String
+    callback n args (CFFun s t) = callback n (s :: args) t
+    callback n args_rev retty
+        = do let args = reverse args_rev
+             argTypes <- traverse (cftySpec fc) (filter notWorld args)
+             retType <- cftySpec fc retty
+             pure $ mkFun args retty n -- FIXME Needs a top-level c-define
+
+    buildArg : (Name, CFType) -> Core String
+    buildArg (n, CFFun s t) = callback (schName n) [s] t
+    buildArg (n, _) = pure $ schName n
+
+schemeCall : FC -> (sfn : String) ->
+             List Name -> CFType -> Core String
+schemeCall fc sfn argns ret
+    = let call = "(" ++ sfn ++ " " ++ showSep " " (map schName argns) ++ ")" in
+          case ret of
+               CFIORes _ => pure $ mkWorld call
+               _ => pure call
+
+-- Use a calling convention to compile a foreign def.
+-- Returns any preamble needed for loading libraries, and the body of the
+-- function call.
+useCC : {auto c : Ref Ctxt Defs} ->
+        {auto l : Ref Loaded (List String)} ->
+        FC -> List String -> List (Name, CFType) -> CFType -> Core (String, String)
+useCC fc [] args ret
+    = throw (GenericMsg fc "No recognised foreign calling convention")
+useCC fc (cc :: ccs) args ret
+    = case parseCC cc of
+           Nothing => useCC fc ccs args ret
+           Just ("scheme", [sfn]) =>
+               do body <- schemeCall fc sfn (map fst args) ret
+                  pure ("", body)
+           Just ("C", [cfn, clib]) => cCall fc cfn clib args ret
+           Just ("C", [cfn, clib, chdr]) => cCall fc cfn clib args ret
+           _ => useCC fc ccs args ret
+
+-- For every foreign arg type, return a name, and whether to pass it to the
+-- foreign call (we don't pass '%World')
+mkArgs : Int -> List CFType -> List (Name, Bool)
+mkArgs i [] = []
+mkArgs i (CFWorld :: cs) = (MN "farg" i, False) :: mkArgs i cs
+mkArgs i (c :: cs) = (MN "farg" i, True) :: mkArgs (i + 1) cs
+
+mkStruct : {auto s : Ref Structs (List String)} ->
+           CFType -> Core String
+mkStruct (CFStruct n flds)
+    = do defs <- traverse mkStruct (map snd flds)
+         strs <- get Structs
+         if n `elem` strs
+            then pure (concat defs)
+            else do put Structs (n :: strs)
+                    pure $ concat defs ++ "(define-c-struct " ++ n ++ " "
+                           ++ showSep " " !(traverse showFld flds) ++ ")\n"
+  where
+    showFld : (String, CFType) -> Core String
+    showFld (n, ty) = pure $ "(" ++ n ++ " " ++ !(cftySpec emptyFC ty) ++ ")"
+mkStruct (CFIORes t) = mkStruct t
+mkStruct (CFFun a b) = do mkStruct a; mkStruct b
+mkStruct _ = pure ""
+
+schFgnDef : {auto c : Ref Ctxt Defs} ->
+            {auto l : Ref Loaded (List String)} ->
+            {auto s : Ref Structs (List String)} ->
+            FC -> Name -> CDef -> Core (String, String)
+schFgnDef fc n (MkForeign cs args ret)
+    = do let argns = mkArgs 0 args
+         let allargns = map fst argns
+         let useargns = map fst (filter snd argns)
+         argStrs <- traverse mkStruct args
+         retStr <- mkStruct ret
+         (load, body) <- useCC fc cs (zip useargns args) ret
+         defs <- get Ctxt
+         pure (load,
+                concat argStrs ++ retStr ++
+                "(define " ++ schName !(full (gamma defs) n) ++
+                " (lambda (" ++ showSep " " (map schName allargns) ++ ") " ++
+                body ++ "))\n")
+schFgnDef _ _ _ = pure ("", "")
+
+getFgnCall : {auto c : Ref Ctxt Defs} ->
+             {auto l : Ref Loaded (List String)} ->
+             {auto s : Ref Structs (List String)} ->
+             Name -> Core (String, String)
+getFgnCall n
+    = do defs <- get Ctxt
+         case !(lookupCtxtExact n (gamma defs)) of
+           Nothing => throw (InternalError ("Compiling undefined name " ++ show n))
+           Just def => case compexpr def of
+                          Nothing =>
+                             throw (InternalError ("No compiled definition for " ++ show n))
+                          Just d => schFgnDef (location def) n d
+
+-- TODO Include libraries from the directives
 compileToSCM : Ref Ctxt Defs ->
                ClosedTerm -> (outfile : String) -> Core ()
 compileToSCM c tm outfile
-    = do -- XXX
-         -- ds <- getDirectives Gambit
-         -- libs <- findLibs ds
-         -- traverse_ copyLib libs
-         cdata <- getCompileData tm
+    = do cdata <- getCompileData tm
          let ns = allNames cdata
-         let tags = nameTags cdata
+         -- let tags = nameTags cdata
          let ctm = forget (mainExpr cdata)
 
          defs <- get Ctxt
-         l <- newRef {t = List String} Loaded [] -- XXX ["libc", "libc 6"]
+         l <- newRef {t = List String} Loaded []
          s <- newRef {t = List String} Structs []
-         -- fgndefs <- traverse getFgnCall ns
+         fgndefs <- traverse getFgnCall ns
          compdefs <- traverse (getScheme gambitPrim gambitString defs) ns
-         let code = concat compdefs -- XXX
-         -- let code = fastAppend (map snd fgndefs ++ compdefs)
+         let code = fastAppend (map snd fgndefs ++ compdefs) ++
+                    concat (map fst fgndefs)
          main <- schExp gambitPrim gambitString 0 ctm
          support <- readDataFile "gambit/support.scm"
-         let scm = schHeader ++ support ++ code ++ main ++ schFooter -- XXX
+         foreign <- readDataFile "gambit/foreign.scm"
+         let scm = showSep "\n" [schHeader, support, foreign, code, main]
          Right () <- coreLift $ writeFile outfile scm
             | Left err => throw (FileErr outfile err)
-         coreLift $ chmod outfile 0o755
          pure ()
 
--- TODO Allow specifying if we want a dynamic obj file or an executable binary
--- Look at what is done in Chez Scheme
+-- TODO Include external libraries on compilation
 compileExpr : Ref Ctxt Defs -> (execDir : String) ->
               ClosedTerm -> (outfile : String) -> Core (Maybe String)
 compileExpr c execDir tm outfile

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -39,12 +39,10 @@ schHeader = "(declare (block)
 schFooter : String
 schFooter = "\n"
 
+-- XXX
 showGambitChar : Char -> String -> String
 showGambitChar '\\' = ("\\\\" ++)
-showGambitChar c
-   = if c < chr 32 || c > chr 126
-        then (("\\x" ++ asHex (cast c) ++ ";") ++)
-        else strCons c
+showGambitChar c = strCons c
 
 showGambitString : List Char -> String -> String
 showGambitString [] = id

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -1,0 +1,144 @@
+module Compiler.Scheme.Gambit
+
+import Compiler.Common
+import Compiler.CompileExpr
+import Compiler.Inline
+import Compiler.Scheme.Common
+
+import Core.Context
+import Core.Directory
+import Core.Name
+import Core.Options
+import Core.TT
+
+import Utils.Hex
+
+import Data.NameMap
+import Data.Vect
+import System
+import System.Info
+
+%default covering
+
+findGSI : IO String
+findGSI =
+  do env <- getEnv "GAMBIT_GSI"
+     pure $ fromMaybe "/usr/bin/env -S gsi-script" env
+
+findGSC : IO String
+findGSC =
+  do env <- getEnv "GAMBIT_GSC"
+     pure $ fromMaybe "/usr/bin/env -S gsc-script" env
+
+-- XXX
+schHeader : String
+schHeader = ""
+
+-- XXX
+schFooter : String
+schFooter = "\n"
+
+showGambitChar : Char -> String -> String
+showGambitChar '\\' = ("\\\\" ++)
+showGambitChar c
+   = if c < chr 32 || c > chr 126
+        then (("\\x" ++ asHex (cast c) ++ ";") ++)
+        else strCons c
+
+showGambitString : List Char -> String -> String
+showGambitString [] = id
+showGambitString ('"'::cs) = ("\\\"" ++) . showGambitString cs
+showGambitString (c::cs) = (showGambitChar c) . showGambitString cs
+
+gambitString : String -> String
+gambitString cs = strCons '"' (showGambitString (unpack cs) "\"")
+
+mutual
+  gambitPrim : Int -> ExtPrim -> List NamedCExp -> Core String
+  gambitPrim i CCall [ret, NmPrimVal fc (Str fn), fargs, world]
+      = throw (InternalError ("Can't compile C FFI calls to Gambit yet")) -- TODO
+  gambitPrim i CCall [ret, fn, args, world]
+      = pure "(error \"bad ffi call\")"
+  gambitPrim i GetStr [world]
+      = pure $ mkWorld "(read-line (current-input-port))"
+  gambitPrim i GetField [NmPrimVal _ (Str s), _, _, struct,
+                         NmPrimVal _ (Str fld), _]
+      = do structsc <- schExp gambitPrim gambitString 0 struct
+           pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")" -- FIXME
+  gambitPrim i GetField [_,_,_,_,_,_]
+      = pure "(error \"bad getField\")"
+  gambitPrim i SetField [NmPrimVal _ (Str s), _, _, struct,
+                         NmPrimVal _ (Str fld), _, val, world]
+      = do structsc <- schExp gambitPrim gambitString 0 struct
+           valsc <- schExp gambitPrim gambitString 0 val
+           pure $ mkWorld $
+                "(set-" ++ s ++ "-" ++ fld ++ "! " ++ structsc ++ " " ++ valsc ++ ")" -- FIXME
+  gambitPrim i SetField [_,_,_,_,_,_,_,_]
+      = pure "(error \"bad setField\")"
+  gambitPrim i SysCodegen []
+      = pure $ "\"gambit\""
+  gambitPrim i prim args
+      = schExtCommon gambitPrim gambitString i prim args
+
+-- Reference label for keeping track of loaded external libraries
+data Loaded : Type where
+
+-- Label for noting which struct types are declared
+data Structs : Type where
+
+-- TODO Support C FFI and libraries
+
+compileToSCM : Ref Ctxt Defs ->
+               ClosedTerm -> (outfile : String) -> Core ()
+compileToSCM c tm outfile
+    = do -- XXX
+         -- ds <- getDirectives Gambit
+         -- libs <- findLibs ds
+         -- traverse_ copyLib libs
+         cdata <- getCompileData tm
+         let ns = allNames cdata
+         let tags = nameTags cdata
+         let ctm = forget (mainExpr cdata)
+
+         defs <- get Ctxt
+         l <- newRef {t = List String} Loaded [] -- XXX ["libc", "libc 6"]
+         s <- newRef {t = List String} Structs []
+         -- fgndefs <- traverse getFgnCall ns
+         compdefs <- traverse (getScheme gambitPrim gambitString defs) ns
+         let code = concat compdefs -- XXX
+         -- let code = fastAppend (map snd fgndefs ++ compdefs)
+         main <- schExp gambitPrim gambitString 0 ctm
+         support <- readDataFile "gambit/support.scm"
+         let scm = schHeader ++ support ++ code ++ main ++ schFooter -- XXX
+         Right () <- coreLift $ writeFile outfile scm
+            | Left err => throw (FileErr outfile err)
+         coreLift $ chmod outfile 0o755
+         pure ()
+
+-- TODO Allow specifying if we want a dynamic obj file or an executable binary
+-- Look at what is done in Chez Scheme
+compileExpr : Ref Ctxt Defs -> (execDir : String) ->
+              ClosedTerm -> (outfile : String) -> Core (Maybe String)
+compileExpr c execDir tm outfile
+    = do let outn = execDir ++ dirSep ++ outfile ++ ".scm"
+         compileToSCM c tm outn
+         gsc <- coreLift findGSC
+         ok <- coreLift $ system (gsc ++ " -exe " ++ outn)
+         if ok == 0
+            then pure (Just outfile)
+            else pure Nothing
+
+-- TODO Would it be better to compile to dynamic obj file and use gsi or gsc -i
+-- Look at what is done in Chez Scheme
+executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
+executeExpr c execDir tm
+    = do tmp <- coreLift $ tmpName
+         let outn = tmp ++ ".scm"
+         compileToSCM c tm outn
+         gsi <- coreLift findGSI
+         coreLift $ system (gsi ++ " " ++ outn)
+         pure ()
+
+export
+codegenGambit : Codegen
+codegenGambit = MkCG compileExpr executeExpr

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -32,12 +32,12 @@ findGSC =
   do env <- getEnv "GAMBIT_GSC"
      pure $ fromMaybe "/usr/bin/env -S gsc-script" env
 
--- TODO Tweak the header for optimal results
 schHeader : String
 schHeader = "(declare (block)
          (standard-bindings)
          (extended-bindings)
-         (not safe))\n"
+         (not safe)
+         (optimize-dead-definitions))\n"
 
 showGambitChar : Char -> String -> String
 showGambitChar '\\' = ("\\\\" ++)

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -30,11 +30,12 @@ findGSC =
   do env <- getEnv "GAMBIT_GSC"
      pure $ fromMaybe "/usr/bin/env -S gsc-script" env
 
--- XXX
 schHeader : String
-schHeader = ""
+schHeader = "(declare (block)
+         (standard-bindings)
+         (extended-bindings)
+         (not safe))\n\n"
 
--- XXX
 schFooter : String
 schFooter = "\n"
 
@@ -128,8 +129,6 @@ compileExpr c execDir tm outfile
             then pure (Just outfile)
             else pure Nothing
 
--- TODO Would it be better to compile to dynamic obj file and use gsi or gsc -i
--- Look at what is done in Chez Scheme
 executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
 executeExpr c execDir tm
     = do tmp <- coreLift $ tmpName

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -63,7 +63,7 @@ mutual
   gambitPrim i GetField [NmPrimVal _ (Str s), _, _, struct,
                          NmPrimVal _ (Str fld), _]
       = do structsc <- schExp gambitPrim gambitString 0 struct
-           pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")" -- FIXME
+           pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")" -- XXX
   gambitPrim i GetField [_,_,_,_,_,_]
       = pure "(error \"bad getField\")"
   gambitPrim i SetField [NmPrimVal _ (Str s), _, _, struct,
@@ -71,7 +71,7 @@ mutual
       = do structsc <- schExp gambitPrim gambitString 0 struct
            valsc <- schExp gambitPrim gambitString 0 val
            pure $ mkWorld $
-                "(set-" ++ s ++ "-" ++ fld ++ "! " ++ structsc ++ " " ++ valsc ++ ")" -- FIXME
+                "(" ++ s ++ "-" ++ fld ++ "-set! " ++ structsc ++ " " ++ valsc ++ ")" -- XXX
   gambitPrim i SetField [_,_,_,_,_,_,_,_]
       = pure "(error \"bad setField\")"
   gambitPrim i SysCodegen []

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -35,12 +35,14 @@ public export
 data CG = Chez
         | Chicken
         | Racket
+        | Gambit
 
 export
 Eq CG where
   Chez == Chez = True
   Chicken == Chicken = True
   Racket == Racket = True
+  Gambit == Gambit = True
   _ == _ = False
 
 export
@@ -48,7 +50,8 @@ availableCGs : List (String, CG)
 availableCGs
     = [("chez", Chez),
        ("chicken", Chicken),
-       ("racket", Racket)]
+       ("racket", Racket),
+       ("gambit", Gambit)]
 
 export
 getCG : String -> Maybe CG

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -718,12 +718,14 @@ TTC CG where
   toBuf b Chez = tag 0
   toBuf b Chicken = tag 1
   toBuf b Racket = tag 2
+  toBuf b Gambit = tag 3
 
   fromBuf b
       = case !getTag of
              0 => pure Chez
              1 => pure Chicken
              2 => pure Racket
+             3 => pure Gambit
              _ => corrupt "CG"
 
 export

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -3,6 +3,7 @@ module Idris.IDEMode.REPL
 import Compiler.Scheme.Chez
 -- import Compiler.Scheme.Chicken
 import Compiler.Scheme.Racket
+import Compiler.Scheme.Gambit
 import Compiler.Common
 
 import Core.AutoSearch

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -3,6 +3,7 @@ module Idris.REPL
 import Compiler.Scheme.Chez
 -- import Compiler.Scheme.Chicken
 import Compiler.Scheme.Racket
+import Compiler.Scheme.Gambit
 import Compiler.Common
 
 import Core.AutoSearch
@@ -241,6 +242,7 @@ findCG
               Chicken => throw (InternalError "Chicken CG not available")
                          -- pure codegenChicken
               Racket => pure codegenRacket
+              Gambit => pure codegenGambit
 
 anyAt : (FC -> Bool) -> FC -> a -> Bool
 anyAt p loc y = p loc

--- a/support/gambit/foreign.scm
+++ b/support/gambit/foreign.scm
@@ -1,0 +1,69 @@
+;; Copyright 2009 Marc Feeley <feeley@iro.umontreal.ca>
+;; Licensed under Apache 2.0 or LGPL 2.1
+
+(define-macro (define-c-struct type . fields)
+  (let* ((type-str
+           (symbol->string type))
+         (struct-type-str
+           (string-append "struct " type-str))
+         (release-type-str
+           (string-append "release_" type-str))
+         (sym
+           (lambda strs (string->symbol (apply string-append strs))))
+         (type*
+           (sym type-str "*"))
+         (type*/nonnull
+           (sym type-str "*/nonnull"))
+         (type*/release-rc
+           (sym type-str "*/release-rc"))
+         (expansion
+           `(begin
+
+             ;; Release function which is called when the object
+             ;; is no longer accessible from the Scheme world
+
+             (c-declare
+               ,(string-append
+                  "static ___SCMOBJ " release-type-str "(void* ptr)\n"
+                  "{\n"
+                  "  ___EXT(___release_rc)(ptr);\n"
+                  "  return ___FIX(___NO_ERR);\n"
+                  "}\n"))
+
+             ;; C types
+
+             (c-define-type ,type (struct ,type-str))
+             (c-define-type ,type* (pointer ,type (,type*)))
+             (c-define-type ,type*/nonnull (nonnull-pointer ,type (,type*)))
+             (c-define-type ,type*/release-rc (nonnull-pointer ,type (,type*) ,release-type-str))
+
+             ;; Type allocator procedure
+
+             (define ,(sym "alloc-" type-str)
+               (c-lambda ()
+                         ,type*/release-rc
+                         ,(string-append "___result_voidstar = ___EXT(___alloc_rc)(sizeof(" struct-type-str "));")))
+
+             ;; Field getters
+
+             ,@(map (lambda (field)
+                      (let ((field-str (symbol->string (car field)))
+                            (field-type (cadr field)))
+                        `(define ,(sym type-str "-" field-str)
+                          (c-lambda (,type*/nonnull)
+                                    ,field-type
+                                    ,(string-append "___result = ___arg1->" field-str ";")))))
+                    fields)
+
+             ;; Field setters
+
+             ,@(map (lambda (field)
+                      (let ((field-str (symbol->string (car field)))
+                            (field-type (cadr field)))
+                        `(define ,(sym type-str "-" field-str "-set!")
+                          (c-lambda (,type*/nonnull ,field-type)
+                                    void
+                                    ,(string-append "___arg1->" field-str " = ___arg2;")))))
+                    fields))))
+
+             expansion))

--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -1,0 +1,236 @@
+(define (blodwen-read-args desc)
+  (case (vector-ref desc 0)
+    ((0) '())
+    ((1) (cons (vector-ref desc 2)
+               (blodwen-read-args (vector-ref desc 3))))))
+
+(define (b+ x y bits) (remainder (+ x y) (arithmetic-shift 1 bits)))
+(define (b- x y bits) (remainder (- x y) (arithmetic-shift 1 bits)))
+(define (b* x y bits) (remainder (* x y) (arithmetic-shift 1 bits)))
+(define (b/ x y bits) (remainder (exact-floor (/ x y)) (arithmetic-shift 1 bits)))
+
+(define blodwen-and bitwise-and)
+(define blodwen-or bitwise-ior)
+(define blodwen-xor bitwise-xor)
+(define blodwen-shl arithmetic-shift)
+(define (blodwen-shr x y) (arithmetic-shift x (- y)))
+
+(define exact-floor ##flonum->fixnum) ; XXX
+
+(define (cast-string-double x)
+  (define (cast-num x)
+    (if (number? x) x 0))
+  (define (destroy-prefix x)
+    (if (or (equal? x "") (char=? (string-ref x 0) #\#)) "" x))
+  (cast-num (string->number (destroy-prefix x))))
+
+(define (cast-string-int x)
+  (exact-floor (cast-string-double x)))
+
+(define (string-cons x y)
+  (string-append (string x) y))
+
+(define (string-reverse x)
+  (list->string (reverse! (string->list x))))
+
+(define (string-substr off len s)
+  (let* ((start (max 0 off))
+         (end (min (+ start (max 0 len))
+                   (string-length s))))
+    (substring s start end)))
+
+(define (get-tag x)
+  (vector-ref x 0))
+
+;; These two are only used in this file
+(define (either-left x) (vector 0 x))
+(define (either-right x) (vector 1 x))
+
+(define (blodwen-error-quit msg)
+  (display msg)
+  (newline)
+  (exit 1))
+
+;; Buffers
+
+(define blodwen-new-buffer make-bytevector)
+(define blodwen-buffer-size bytevector-length)
+
+(define blodwen-buffer-setbyte u8vector-set!)
+(define blodwen-buffer-getbyte u8vector-ref)
+
+(define blodwen-buffer-setint s32vector-set!)
+(define blodwen-buffer-getint s32vector-ref)
+
+(define blodwen-buffer-setdouble f64vector-set!)
+(define blodwen-buffer-getdouble f64vector-ref)
+
+(define (blodwen-stringbytelen str)
+  (bytevector-length (string->utf8 str)))
+
+(define (blodwen-buffer-setstring buf loc val)
+  (let* ((strvec (string->utf8 val))
+         (len (bytevector-length strvec)))
+    (bytevector-copy! strvec 0 buf loc len)))
+
+(define (blodwen-buffer-getstring buf loc len)
+  (let ((newvec (make-bytevector len)))
+    (bytevector-copy! buf loc newvec 0 len)
+    (utf8->string newvec)))
+
+(define (blodwen-buffer-copydata buf start len dest loc)
+  (bytevector-copy! buf start dest loc len))
+
+(define (blodwen-readbuffer-bytes h buf loc max)
+  (with-exception-catcher
+    (lambda (e) -1)
+    (lambda () (read-subu8vector buf loc (+ loc max) h))))
+
+(define (blodwen-readbuffer h)
+  (with-exception-catcher
+    (lambda (e) #u8())
+    (lambda () (list->u8vector (read-all h read-u8)))))
+
+(define (blodwen-writebuffer h buf loc max)
+  (with-exception-catcher
+    (lambda (e) -1)
+    (lambda () (write-subu8vector buf loc (+ loc max) h) max)))
+
+;; Files
+
+;; If the file operation raises an error, catch it and return an appropriate
+;; error code
+(define (blodwen-file-op op)
+  ;; All the file operations are implemented as primitives which return
+  ;; Either Int x, where the Int is an error code:
+  (define (blodwen-error-code x)
+    (either-left
+      ;; TODO Equivalent of i/o-read-error? and i/o-write-error?
+      ;; TODO Uncomment on the next release (> 4.9.3) of Gambit
+      (cond ((no-such-file-or-directory-exception? x) 3)
+            ; ((permission-denied-exception? x) 4)
+            ; ((file-exists-exception? x) 5)
+            (else 255))))
+  (with-exception-catcher
+    blodwen-error-code
+    (lambda () (either-right (op)))))
+
+#|
+(define (blodwen-get-n n p)
+  (if (input-port? p) (read-string n p) ""))
+|#
+
+(define (blodwen-putstring p s)
+  (if (output-port? p) (write-string s p))
+  0)
+
+(define (blodwen-open file mode bin)
+  (define settings
+    (if (fx= bin 1)
+        `(path: ,file buffering: line)
+        `(path: ,file buffering: line char-encoding: UTF-8)))
+  (cond
+    ((string=? mode "r") (open-input-file settings))
+    ((string=? mode "w") (open-output-file settings))
+    ((string=? mode "wx") (open-output-file (append settings '(create: #t))))
+    ((string=? mode "a") (open-output-file (append settings '(append: #t))))
+    ((string=? mode "r+") (open-file settings))
+    ((string=? mode "w+") (open-file (append settings '(create: maybe truncate: #t))))
+    ((string=? mode "w+x") (open-file (append settings '(create: #t truncate: #t))))
+    ((string=? mode "a+") (open-file (append settings '(create: maybe append: #t))))
+    (else (raise 'i/o-error)))) ; XXX
+
+(define (blodwen-close-port p)
+  (if (port? p) (close-port p)))
+
+(define (blodwen-get-line p)
+  (if (input-port? p)
+      (let ((str (read-line p #\newline #t)))
+        (if (eof-object? str) "" str))
+      ""))
+
+(define (blodwen-get-char p)
+  (if (input-port? p)
+      (let ((chr (read-char p)))
+        (if (eof-object? chr) #\nul chr))
+      #\nul))
+
+(define (blodwen-file-modified-time p) ; XXX
+  (exact-floor (time->seconds (file-last-modification-time (##port-name p)))))
+
+#|
+(define (blodwen-file-size p) ; XXX
+  (file-size (##port-name p)))
+|#
+
+(define (blodwen-eof p)
+  (if (eof-object? (peek-char p)) 1 0))
+
+;; Directories
+
+(define blodwen-current-directory current-directory)
+
+(define (blodwen-change-directory dir)
+  (with-exception-catcher
+    (lambda (e) 0)
+    (lambda () (current-directory dir) 1)))
+
+(define (blodwen-create-directory dir)
+  (blodwen-file-op (lambda () (create-directory dir) 0)))
+
+(define (blodwen-open-directory dir)
+  (blodwen-file-op (lambda () (open-directory dir))))
+
+(define blodwen-close-directory close-input-port)
+
+(define (blodwen-next-dir-entry dir)
+  (let ((e (read dir)))
+    (if (eof-object? e)
+        (either-left 255)
+        (either-right e))))
+
+;; Threads
+
+(define (blodwen-thread p)
+  (thread-start! (make-thread (lambda () (p #(0))))))
+
+(define (blodwen-get-thread-data)
+  (let ((data (thread-specific (current-thread))))
+    (if (eq? data #!void) #f data)))
+
+(define (blodwen-set-thread-data a)
+  (thread-specific-set! (current-thread) a))
+
+(define blodwen-mutex make-mutex)
+(define blodwen-lock mutex-lock!)
+(define blodwen-unlock mutex-unlock!)
+(define blodwen-thisthread current-thread)
+
+(define blodwen-condition make-condition-variable)
+(define blodwen-condition-signal condition-variable-signal!)
+(define blodwen-condition-broadcast condition-variable-broadcast!)
+(define (blodwen-condition-wait c m)
+  (mutex-unlock! m c)
+  (mutex-lock! m))
+(define (blodwen-condition-wait-timeout c m t) ; XXX
+  (mutex-unlock! m c t)
+  (mutex-lock! m))
+
+(define blodwen-sleep thread-sleep!)
+(define (blodwen-usleep s) (thread-sleep! (/ s 1e6)))
+
+(define (blodwen-time)
+  (exact-floor (time->seconds (current-time))))
+
+(define (blodwen-args)
+  (define (blodwen-build-args args)
+    (if (null? args)
+        #(0) ; Prelude.List
+        (vector 1 (car args) (blodwen-build-args (cdr args)))))
+  (blodwen-build-args (cdr (command-line))))
+
+(define (blodwen-hasenv var)
+  (if (getenv var #f) 1 0))
+
+(define (blodwen-system cmd)
+  (fxarithmetic-shift-right (shell-command cmd) 8))

--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -104,13 +104,15 @@
   ;; All the file operations are implemented as primitives which return
   ;; Either Int x, where the Int is an error code:
   (define (blodwen-error-code x)
+    (define magic ;; For errno extraction
+      (fx- 0 (fxnot (- (fxarithmetic-shift 1 29) 1)) (fxarithmetic-shift 320 16)))
     (either-left
       ;; TODO Equivalent of i/o-read-error? and i/o-write-error?
       ;; TODO Uncomment on the next release (> 4.9.3) of Gambit
       (cond ((no-such-file-or-directory-exception? x) 3)
             ; ((permission-denied-exception? x) 4)
             ; ((file-exists-exception? x) 5)
-            (else 255))))
+            (else (fx+ (os-exception-code x) magic 256)))))
   (with-exception-catcher
     blodwen-error-code
     (lambda () (either-right (op)))))

--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -53,33 +53,33 @@
 
 ;; Buffers
 
-(define blodwen-new-buffer make-bytevector)
-(define blodwen-buffer-size bytevector-length)
+(define blodwen-new-buffer make-u8vector)
+(define blodwen-buffer-size u8vector-length)
 
-(define blodwen-buffer-setbyte u8vector-set!)
-(define blodwen-buffer-getbyte u8vector-ref)
+(define blodwen-buffer-setbyte ##u8vector-set!)
+(define blodwen-buffer-getbyte ##u8vector-ref)
 
-(define blodwen-buffer-setint s32vector-set!)
-(define blodwen-buffer-getint s32vector-ref)
+(define blodwen-buffer-setint ##s32vector-set!)
+(define blodwen-buffer-getint ##s32vector-ref)
 
-(define blodwen-buffer-setdouble f64vector-set!)
-(define blodwen-buffer-getdouble f64vector-ref)
+(define blodwen-buffer-setdouble ##f64vector-set!)
+(define blodwen-buffer-getdouble ##f64vector-ref)
 
 (define (blodwen-stringbytelen str)
-  (bytevector-length (string->utf8 str)))
+  (u8vector-length (string->utf8 str)))
 
 (define (blodwen-buffer-setstring buf loc val)
   (let* ((strvec (string->utf8 val))
-         (len (bytevector-length strvec)))
-    (bytevector-copy! strvec 0 buf loc len)))
+         (len (u8vector-length strvec)))
+    (u8vector-copy! buf loc strvec 0 len)))
 
 (define (blodwen-buffer-getstring buf loc len)
-  (let ((newvec (make-bytevector len)))
-    (bytevector-copy! buf loc newvec 0 len)
+  (let ((newvec (make-u8vector len)))
+    (u8vector-copy! newvec 0 buf loc (+ loc len))
     (utf8->string newvec)))
 
 (define (blodwen-buffer-copydata buf start len dest loc)
-  (bytevector-copy! buf start dest loc len))
+  (u8vector-copy! dest loc buf start (+ start len)))
 
 (define (blodwen-readbuffer-bytes h buf loc max)
   (with-exception-catcher
@@ -108,7 +108,7 @@
       (fx- 0 (fxnot (- (fxarithmetic-shift 1 29) 1)) (fxarithmetic-shift 320 16)))
     (either-left
       ;; TODO Equivalent of i/o-read-error? and i/o-write-error?
-      ;; TODO Uncomment on the next release (> 4.9.3) of Gambit
+      ;; TODO Uncomment the lines below on the next release (> 4.9.3) of Gambit
       (cond ((no-such-file-or-directory-exception? x) 3)
             ; ((permission-denied-exception? x) 4)
             ; ((file-exists-exception? x) 5)


### PR DESCRIPTION
[Gambit](https://github.com/gambit/gambit) is a mature Scheme compiler and [one of the fastest](https://ecraven.github.io/r7rs-benchmarks).

To give an idea, this is the time on average (after a few runs) for the execution of `tests/chez/chez015/Numbers.idr` (biased in favor of Chez).

```
~/W/Idris2 $ time ./idris2 --cg chez tests/chez/chez015/Numbers.idr -x main
[3518437212327232157160858338944, 1537557061787000452679295093927559, 3518437212327232157160858338070, 8051343735302590748651849744, 379]
[8650625671965379659, 5435549321212129090, 8650625671965378905, 365458446121836181, 357]

________________________________________________________
Executed in  464.05 millis    fish           external
   usr time  402.81 millis    0.00 millis  402.81 millis
   sys time   58.61 millis    3.25 millis   55.36 millis
```

```
~/W/Idris2 $ time ./idris2 --cg gambit tests/chez/chez015/Numbers.idr -x main
[3518437212327232157160858338944, 1537557061787000452679295093927559, 3518437212327232157160858338070, 8051343735302590748651849744, 379]
[8650625671965379659, 5435549321212129090, 8650625671965378905, 365458446121836181, 357]

________________________________________________________
Executed in  282.26 millis    fish           external
   usr time  237.35 millis    0.03 millis  237.33 millis
   sys time   43.03 millis    3.61 millis   39.43 millis
```

Another test with compilation involved (slower compilation time on Gambit):

```
~/W/Idris2 $ ./idris2 --cg chez tests/chez/chez007/TypeCase.idr -o chez-typecase
~/W/Idris2 $ ./idris2 --cg gambit tests/chez/chez007/TypeCase.idr -o gambit-typecase
```

```
~/W/I/b/exec $ time ./chez-typecase
"Function from Nat to Nat"
"Function from Nat to Vector of 0 Int"
"Function on Type"

________________________________________________________
Executed in  182.32 millis    fish           external
   usr time  151.08 millis    0.00 millis  151.08 millis
   sys time   30.13 millis    3.50 millis   26.63 millis
```

```
~/W/I/b/exec $ time ./gambit-typecase
"Function from Nat to Nat"
"Function from Nat to Vector of 0 Int"
"Function on Type"

________________________________________________________
Executed in   12.82 millis    fish           external
   usr time    3.11 millis    0.00 millis    3.11 millis
   sys time    8.81 millis    2.63 millis    6.18 millis
```

Gambit also has many backends, like JavaScript, which may be of interest for #276 (at least for early prototyping).

This is still a work in progress. I plan for parity with Chez.