### PR TITLE
Check for EOF when reading from an input port

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -127,8 +127,6 @@ mutual
   chezExtPrim i CCall [ret, fn, args, world]
       = pure "(error \"bad ffi call\")"
       -- throw (InternalError ("C FFI calls must be to statically known functions (" ++ show fn ++ ")"))
-  chezExtPrim i GetStr [world]
-      = pure $ mkWorld "(get-line (current-input-port))"
   chezExtPrim i GetField [NmPrimVal _ (Str s), _, _, struct,
                              NmPrimVal _ (Str fld), _]
       = do structsc <- schExp chezExtPrim chezString 0 struct

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -157,15 +157,20 @@
     (when (port? p) (close-port p)))
 
 (define (blodwen-get-line p)
-    (if (and (port? p) (not (port-eof? p)))
+    (if (port? p)
         (let ((str (get-line p)))
-            (string-append str "\n"))
-        ""))
+            (if (eof-object? str)
+                ""
+                str))
+        void))
 
 (define (blodwen-get-char p)
-    (if (and (port? p) (not (port-eof? p)))
-        (get-char p)
-        #\nul))
+    (if (port? p)
+        (let ((chr (get-char p)))
+            (if (eof-object? chr)
+                #\nul
+                chr))
+        void))
 
 (define (blodwen-file-modified-time p)
     (time-second (file-modification-time p)))

--- a/support/chicken/support.scm
+++ b/support/chicken/support.scm
@@ -93,15 +93,15 @@
         (let ((str (read-line p)))
             (if (eof-object? str)
                 ""
-                (string-append str "\n")))
+                str))
         void))
 
 (define (blodwen-get-char p)
     (if (port? p)
-        (let ((char (read-char p)))
-            (if (eof-object? char)
+        (let ((chr (read-char p)))
+            (if (eof-object? chr)
                 #\nul
-                char))
+                chr))
         void))
 
 (define (blodwen-eof p)

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -164,15 +164,15 @@
         (let ((str (read-line p)))
             (if (eof-object? str)
                 ""
-                (string-append str "\n")))
+                str))
         void))
 
 (define (blodwen-get-char p)
     (if (port? p)
-        (let ((char (read-char p)))
-            (if (eof-object? char)
+        (let ((chr (read-char p)))
+            (if (eof-object? chr)
                 #\nul
-                char))
+                chr))
         void))
 
 (define (blodwen-eof p)


### PR DESCRIPTION
1) Check for EOF when reading from an input port (Chez backend).

2) Fix `getLine` to read and return a string without the trailing newline.