### PR TITLE
Remove uneeded dependency on tests.ipkg

### DIFF
--- a/tests.ipkg
+++ b/tests.ipkg
@@ -1,7 +1,5 @@
 package runtests
 
-pkgs = contrib
-
 sourcedir = tests
 executable = runtests
 


### PR DESCRIPTION
Fixes #321 