### PR TITLE
Make System.File.readFile keep newlines

### DIFF
--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -147,7 +147,7 @@ readFile file
                 else
                   do Right str <- fGetLine h
                         | Left err => pure (Left err)
-                     read (str :: "\n" :: acc) h
+                     read ("\n" :: str :: acc) h  -- this list will be reversed before concatenation
 
 ||| Write a string to a file
 export

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -147,7 +147,7 @@ readFile file
                 else
                   do Right str <- fGetLine h
                         | Left err => pure (Left err)
-                     read (str :: acc) h
+                     read (str :: "\n" :: acc) h
 
 ||| Write a string to a file
 export


### PR DESCRIPTION
`System.File.readFile` on a file containing `"foo\nbar"` returns `"foobar"`.

This patch fixes it. I'm not sure about the efficiency but I hope it's not horrible.