### PR TITLE
Export the implementation of `Traversable (Vect k)`

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -798,7 +798,7 @@ implementation {k : Nat} -> Applicative (Vect k) where
 implementation {k : Nat} -> Monad (Vect k) where
     m >>= f = diag (map f m)
 
-export
+public export
 implementation Traversable (Vect k) where
     traverse f []        = pure []
     traverse f (x :: xs) = [| f x :: traverse f xs |]

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -801,7 +801,7 @@ implementation {k : Nat} -> Monad (Vect k) where
 export
 implementation Traversable (Vect n) where
     traverse f []        = pure []
-    traverse f (x :: xs) = pure (::) <*> (f x) <*> (traverse f xs)
+    traverse f (x :: xs) = [| f x :: traverse f xs |]
 
 --------------------------------------------------------------------------------
 -- Elem

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -799,7 +799,7 @@ implementation {k : Nat} -> Monad (Vect k) where
     m >>= f = diag (map f m)
 
 export
-implementation Traversable (Vect n) where
+implementation Traversable (Vect k) where
     traverse f []        = pure []
     traverse f (x :: xs) = [| f x :: traverse f xs |]
 

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -795,10 +795,11 @@ implementation {k : Nat} -> Applicative (Vect k) where
 
 -- ||| This monad is different from the List monad, (>>=)
 -- ||| uses the diagonal.
-implementation {len : Nat} -> Monad (Vect len) where
+implementation {k : Nat} -> Monad (Vect k) where
     m >>= f = diag (map f m)
 
-implementation {n : Nat} -> Traversable (Vect n) where
+export
+implementation Traversable (Vect n) where
     traverse f []        = pure []
     traverse f (x :: xs) = pure (::) <*> (f x) <*> (traverse f xs)
 


### PR DESCRIPTION
For some reason, it was hidden but it's useful. (I need it.)