### PR TITLE
Add noNewtype option to data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Compiler updates:
 * Data types with a single constructor, with a single unerased arguments,
   are translated to just that argument, to save repeated packing and unpacking.
   (c.f. `newtype` in Haskell)
+  + A data type can opt out of this behaviour by specifying `noNewtype` in its
+    options list. `noNewtype` allows code generators to apply special handling
+    to the generated constructor/deconstructor, for a newtype-like data type,
+    that would otherwise be optimised away.
 * 0-multiplicity constructor arguments are now properly erased, not just
   given a placeholder null value.
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -924,6 +924,8 @@ dataOpt
          pure (SearchBy ns)
   <|> do exactIdent "external"
          pure External
+  <|> do exactIdent "noNewtype"
+         pure NoNewtype
 
 dataBody : FileName -> Int -> FilePos -> Name -> IndentInfo -> PTerm ->
            EmptyRule PDataDecl

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -29,6 +29,8 @@ processDataOpt fc ndef UniqueSearch
     = setUniqueSearch fc ndef True
 processDataOpt fc ndef External
     = setExternal fc ndef True
+processDataOpt fc ndef NoNewtype
+    = pure ()
 
 checkRetType : {auto c : Ref Ctxt Defs} ->
                Env Term vars -> NF vars ->
@@ -330,7 +332,12 @@ processData {vars} eopts nest env fc vis (MkImpData dfc n_in ty_raw opts cons_ra
 
          let ddef = MkData (MkCon dfc n arity fullty) cons
          addData vars vis tidx ddef
-         findNewtype cons
+
+         -- Flag data type as a newtype, if possible (See `findNewtype` for criteria).
+         -- Skip optimisation if the data type has specified `noNewtype` in its
+         -- options list.
+         when (not (NoNewtype `elem` opts)) $
+              findNewtype cons
 
          -- Type is defined mutually with every data type undefined at the
          -- point it was declared, and every data type undefined right now

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -232,6 +232,7 @@ mutual
        NoHints : DataOpt -- Don't generate search hints for constructors
        UniqueSearch : DataOpt -- auto implicit search must check result is unique
        External : DataOpt -- implemented externally
+       NoNewtype : DataOpt -- don't apply newtype optimisation
 
   export
   Eq DataOpt where
@@ -239,6 +240,7 @@ mutual
     (==) NoHints NoHints = True
     (==) UniqueSearch UniqueSearch = True
     (==) External External = True
+    (==) NoNewtype NoNewtype = True
     (==) _ _ = False
 
   public export
@@ -837,6 +839,7 @@ mutual
     toBuf b NoHints = tag 1
     toBuf b UniqueSearch = tag 2
     toBuf b External = tag 3
+    toBuf b NoNewtype = tag 4
 
     fromBuf b
         = case !getTag of
@@ -845,6 +848,7 @@ mutual
                1 => pure NoHints
                2 => pure UniqueSearch
                3 => pure External
+               4 => pure NoNewtype
                _ => corrupt "DataOpt"
 
   export

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -98,7 +98,7 @@ chezTests : List String
 chezTests
    = ["chez001", "chez002", "chez003", "chez004", "chez005", "chez006",
       "chez007", "chez008", "chez009", "chez010", "chez011", "chez012",
-      "chez013", "chez014", "chez015", "chez016",
+      "chez013", "chez014", "chez015", "chez016", "chez017",
       "reg001"]
 
 ideModeTests : List String

--- a/tests/chez/chez017/Main.idr
+++ b/tests/chez/chez017/Main.idr
@@ -1,0 +1,19 @@
+module Main
+
+data Foo : Type where
+  MkFoo : String -> Foo
+
+data Bar : Type where
+  [noNewtype]
+  MkBar : String -> Bar
+
+
+-- This code rely on the fact that `putStr` calls the Chez function `display`,
+-- which allows any value to be printed. This will expose the internal
+-- structure of each data type.
+main : IO ()
+main = do
+  putStr (believe_me (MkFoo "foo"))
+  putChar '\n'
+  putStr (believe_me (MkBar "bar"))
+  putChar '\n'

--- a/tests/chez/chez017/expected
+++ b/tests/chez/chez017/expected
@@ -1,0 +1,4 @@
+foo
+#(0 bar)
+1/1: Building Main (Main.idr)
+Main> Main> Bye for now!

--- a/tests/chez/chez017/input
+++ b/tests/chez/chez017/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/chez/chez017/run
+++ b/tests/chez/chez017/run
@@ -1,0 +1,3 @@
+$1 --no-banner Main.idr < input
+
+rm -rf build


### PR DESCRIPTION
Since the newtype optimisation was added (471a47255fb2757b0efce52560e30a0aa88bdeaa), code generators are no longer able to add special handling of the generated constructor/deconstructor for data types that are affected by the newtype optimisation.

To restore this functionality, I have added a new option (`noNewtype`) to disable the newtype optimisation for individual data types.

### Motivation

In my [Erlang code generator](https://github.com/chrrasmussen/idris2-erlang) I have added [special handling](https://github.com/chrrasmussen/idris2-erlang/blob/66cb4a2d5c00934467484a0694650224a89393f0/idris2/src/Compiler/Erlang/CExp.idr#L125-L133) to some data types, like `ErlAtom`, `ErlBinary` and `ErlCharlist` (from the [`Erlang` module](https://github.com/chrrasmussen/idris2-erlang/blob/66cb4a2d5c00934467484a0694650224a89393f0/idris2/libs/erlang/Erlang.idr#L10-L26)). By doing this I can convert values between an Idris-specific representation to an Erlang-specific representation (and back), like so:

- `MkErlAtom "test"` will generate an Erlang atom: `'test'`
- `MkErlBinary "test"` will generate an Erlang binary: `<<"test"/utf8>>`
- `MkErlCharlist "test"` will generate an Erlang charlist: `"test"`

These data types fulfil the critera for the newtype optimisation, which means that, without the `noNewtype` option, the code generator is unable to add its own special handling.

### Other comments

- The name is supposed to match the existing `noHints` option, but I am happy to change it if anyone has any suggestions.

- The included test is placed in the `chez` section because it rely on printing the internal structure of the data types.