### PR TITLE
--find-pkg load dependencies

### DIFF
--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -486,6 +486,7 @@ findIpkg fname
         pkg <- addFields fs (initPkgDesc pname)
         setSourceDir (sourcedir pkg)
         processOptions (options pkg)
+        loadDependencies (depends pkg)
         case fname of
              Nothing => pure Nothing
              Just src =>
@@ -499,3 +500,5 @@ findIpkg fname
     dropHead str [] = []
     dropHead str (x :: xs)
         = if x == str then xs else x :: xs
+    loadDependencies : List String -> Core ()
+    loadDependencies = traverse_ addPkgDir


### PR DESCRIPTION
It addresses issues #349.

It includes all the packages of the `depends` field when it finds the `ipkg` file.