### PR TITLE
Update chez016 test to not rely on realpath

### DIFF
--- a/tests/chez/chez016/run
+++ b/tests/chez/chez016/run
@@ -1,7 +1,20 @@
-# Get the absolute path to idris2 because we run idris2 from another folder than the current
-IDRIS2_EXEC="$(realpath "$1")"
+# This test needs to run `idris2` from a sub-folder.
+# Split path to `idris2` executable into dirname and basename.
+# If the path is relative, add `..` to compensate for running `idris2` in a sub-folder.
+case "$1" in
+  /*)
+    # Absolute path
+    IDRIS2_DIR="$(dirname "$1")"
+    ;;
+  *)
+    # Relative path
+    IDRIS2_DIR="$(dirname "$1")/.."
+    ;;
+esac
+
+IDRIS2_EXEC="$(basename "$1")"
 
 cd "folder with spaces" || exit
 
-"$IDRIS2_EXEC" --no-banner Main.idr < ../input
+"$IDRIS2_DIR/$IDRIS2_EXEC" --no-banner Main.idr < ../input
 rm -rf build


### PR DESCRIPTION
I was made aware that the command `realpath` is not available on macOS by default. To avoid relying on `realpath` I changed the test to use `dirname`/`basename` instead.

The test runner runs the test using a relative path, i.e.: `./run ../../../idris2`
It is also possible to run the test using an absolute path: `./run ~/.idris2/bin/idris2`