### PR TITLE
[ fix ] `absurd` does not need a runtime argument

### DIFF
--- a/libs/base/Data/List/Elem.idr
+++ b/libs/base/Data/List/Elem.idr
@@ -29,8 +29,8 @@ thereInjective Refl = Refl
 export
 DecEq (Elem x xs) where
   decEq Here Here = Yes Refl
-  decEq Here (There later) = No absurd
-  decEq (There later) Here = No absurd
+  decEq Here (There later) = No (\ prf => absurd prf)
+  decEq (There later) Here = No (\ prf => absurd prf)
   decEq (There this) (There that) with (decEq this that)
     decEq (There this) (There this) | Yes Refl  = Yes Refl
     decEq (There this) (There that) | No contra = No (contra . thereInjective)
@@ -49,7 +49,7 @@ neitherHereNorThere xny xnxs (There xxs) = xnxs xxs
 ||| Check whether the given element is a member of the given list.
 export
 isElem : DecEq a => (x : a) -> (xs : List a) -> Dec (Elem x xs)
-isElem x [] = No absurd
+isElem x [] = No (\ prf => absurd prf)
 isElem x (y :: xs) with (decEq x y)
   isElem x (x :: xs) | Yes Refl = Yes Here
   isElem x (y :: xs) | No xny with (isElem x xs)

--- a/libs/base/Data/Maybe.idr
+++ b/libs/base/Data/Maybe.idr
@@ -23,7 +23,7 @@ Uninhabited (IsJust Nothing) where
 public export
 isItJust : (v : Maybe a) -> Dec (IsJust v)
 isItJust (Just x) = Yes ItIsJust
-isItJust Nothing = No absurd
+isItJust Nothing = No (\ prf => absurd prf)
 
 ||| Convert a `Maybe a` value to an `a` value by providing a default `a` value
 ||| in the case that the `Maybe` value is `Nothing`.

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -28,7 +28,7 @@ Uninhabited (IsSucc Z) where
 
 public export
 isItSucc : (n : Nat) -> Dec (IsSucc n)
-isItSucc Z = No absurd
+isItSucc Z = No (\ prf => absurd prf)
 isItSucc (S n) = Yes ItIsSucc
 
 public export

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -141,7 +141,7 @@ Uninhabited Void where
 ||| @ a the goal type
 ||| @ h the contradictory hypothesis
 public export
-absurd : Uninhabited t => (h : t) -> a
+absurd : Uninhabited t => (0 h : t) -> a
 absurd h = void (uninhabited h)
 
 public export


### PR DESCRIPTION
`absurd` is called to dismiss impossible branches. If we ever start
executing such a branch at runtime we have something to worry about.

Edit: one annoying thing is the fact that `No absurd` is now ill-typed
because `No` expects a `a -> Void` function and not an `0 a -> Void`
one. Manual eta-expansion fixes the problem but it is a bit annoying.
Is it still worth merging this PR in?