### PR TITLE
[ test ] add test for defaulting peculiarity

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -34,7 +34,7 @@ idrisTests
        "basic021", "basic022", "basic023", "basic024", "basic025",
        "basic026", "basic027", "basic028", "basic029", "basic030",
        "basic031", "basic032", "basic033", "basic034", "basic035",
-       "basic036", "basic037", "basic038", "basic039",
+       "basic036", "basic037", "basic038", "basic039", "basic040",
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006",

--- a/tests/idris2/basic040/Default.idr
+++ b/tests/idris2/basic040/Default.idr
@@ -1,0 +1,21 @@
+module Default
+
+happyPairs : List (Nat, Char)
+happyPairs = map (uncurry $ \ c, n => (n, c)) [('a', 1)]
+
+-- In Idris1 `sadPairs` is rejected with the following error:
+--    |
+-- 10 | sadPairs = map (\ (c, n) => (n, c)) [('a', 1)]
+--    |                             ~~
+-- When checking right hand side of Default.case block in sadPairs at Default.idr:10:19-24 with expected type
+--         (Nat, Char)
+
+-- When checking argument a to constructor Builtins.MkPair:
+--         Type mismatch between
+--                 Integer (Type of n)
+--         and
+--                 Nat (Expected type)
+
+
+sadPairs : List (Nat, Char)
+sadPairs = map (\ (c, n) => (n, c)) [('a', 1)]

--- a/tests/idris2/basic040/expected
+++ b/tests/idris2/basic040/expected
@@ -1,0 +1,1 @@
+Default> Bye for now!

--- a/tests/idris2/basic040/expected
+++ b/tests/idris2/basic040/expected
@@ -1,1 +1,2 @@
+1/1: Building Default (Default.idr)
 Default> Bye for now!

--- a/tests/idris2/basic040/run
+++ b/tests/idris2/basic040/run
@@ -1,0 +1,3 @@
+echo ":q" | $1 --no-banner Default.idr
+
+rm -rf build


### PR DESCRIPTION
In Idris1 one of the expressions leads to a type error even though
they are essentially the same. In Idris2 this does not happen.
Adding a test case to make sure we do not inadvertently bring this
kind of behaviour back.