### PR TITLE
Add total version of the fromMaybe

### DIFF
--- a/libs/base/Data/Maybe.idr
+++ b/libs/base/Data/Maybe.idr
@@ -32,6 +32,12 @@ fromMaybe : (Lazy a) -> Maybe a -> a
 fromMaybe def Nothing  = def
 fromMaybe def (Just j) = j
 
+||| Returns the `a` value of a `Maybe a` which is proved `Just`.
+public export
+fromJust : (v : Maybe a) -> IsJust v => a
+fromJust (Just x) = x
+fromJust Nothing impossible
+
 ||| Returns `Just` the given value if the conditional is `True`
 ||| and `Nothing` if the conditional is `False`.
 public export


### PR DESCRIPTION
Add `Data.Maybe.fromJust : (v : Maybe a) -> IsJust v => a`

I think it worth considering if we can also add `fromLeft` and `fromRight` for `Either`.

## Alternative:

Rename `fromMaybe` to `fromMaybe'`, since we usually prime the partial version of the functions. But this is a breaking change.
