### PR TITLE
Refactor Utils.String.stripQuotes to avoid double reversion on Strings

### DIFF
--- a/src/Core/Primitives.idr
+++ b/src/Core/Primitives.idr
@@ -32,7 +32,9 @@ unaryOp _ _ = Nothing
 castString : Vect 1 (NF vars) -> Maybe (NF vars)
 castString [NPrimVal fc (I i)] = Just (NPrimVal fc (Str (show i)))
 castString [NPrimVal fc (BI i)] = Just (NPrimVal fc (Str (show i)))
-castString [NPrimVal fc (Ch i)] = Just (NPrimVal fc (Str (stripQuotes (show i))))
+castString [NPrimVal fc (Ch i)] = case isLTE 2 (length $ show i) of
+                                       Yes prf => Just (NPrimVal fc (Str (stripQuotes (show i))))
+                                       No  _   => Nothing
 castString [NPrimVal fc (Db i)] = Just (NPrimVal fc (Str (show i)))
 castString _ = Nothing
 

--- a/src/Idris/IDEMode/Parser.idr
+++ b/src/Idris/IDEMode/Parser.idr
@@ -20,7 +20,9 @@ ideTokens : TokenMap Token
 ideTokens =
     map (\x => (exact x, Symbol)) symbols ++
     [(digits, \x => Literal (cast x)),
-     (stringLit, \x => StrLit (stripQuotes x)),
+     (stringLit, \x => case isLTE 2 (length x) of
+                            Yes prf => StrLit (stripQuotes x)
+                            No  _   => Unrecognised x),
      (identAllowDashes, \x => NSIdent [x]),
      (space, Comment)]
 

--- a/src/Parser/Lexer.idr
+++ b/src/Parser/Lexer.idr
@@ -251,8 +251,12 @@ rawTokens =
      (hexLit, \x => Literal (fromHexLit x)),
      (octLit, \x => Literal (fromOctLit x)),
      (digits, \x => Literal (cast x)),
-     (stringLit, \x => StrLit (stripQuotes x)),
-     (charLit, \x => CharLit (stripQuotes x)),
+     (stringLit, \x => case isLTE 2 (length x) of
+                            Yes prf => StrLit (stripQuotes x)
+                            No  _   => Unrecognised x),
+     (charLit, \x => case isLTE 2 (length x) of
+                          Yes prf => CharLit (stripQuotes x)
+                          No  _   => Unrecognised x),
      (recField, \x => RecordField (assert_total $ strTail x)),
      (nsIdent, parseNSIdent),
      (ident Normal, parseIdent),

--- a/src/Utils/String.idr
+++ b/src/Utils/String.idr
@@ -3,6 +3,5 @@ module Utils.String
 %default total
 
 export
-stripQuotes : String -> String
--- ASSUMPTION! Only total because we know we're getting quoted strings.
-stripQuotes = assert_total (strTail . reverse . strTail . reverse)
+stripQuotes : (str : String) -> { auto ok : length str `GTE` 2 } -> String
+stripQuotes str = substr 1 (length str - 2) str


### PR DESCRIPTION
Don't know how much of a performance impact this is but [substr](https://github.com/idris-lang/Idris-dev/blob/0417c53fb6b91fc0692245f269b98a3bd4820136/libs/prelude/Prelude/Strings.idr#L361) should be more performant than two string reversals.

Dual of edwinb/Idris2-SH#8